### PR TITLE
Move tests to be closer to source code

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -123,7 +123,6 @@ module.exports = {
   // A list of paths to directories that Jest should use to search for files in
   roots: [
     "<rootDir>/src/client",
-    "<rootDir>/test"
   ],
 
   // Allows you to use a custom runner instead of Jest's default test runner
@@ -133,10 +132,10 @@ module.exports = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ["<rootDir>/src/setupEnzyme.ts"],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
-  // snapshotSerializers: [],
+  snapshotSerializers: ["enzyme-to-json/serializer"],
 
   // The test environment that will be used for testing
   testEnvironment: "node",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@types/enzyme": "^3.10.5",
+    "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/history": "^4.7.3",
     "@types/jest": "^25.2.1",
     "@types/node": "^10.0.3",
@@ -16,6 +18,9 @@
     "@types/react-dom": "16.9.1",
     "compression-webpack-plugin": "^3.0.0",
     "css-loader": "^3.2.0",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-react-16": "^1.15.2",
+    "enzyme-to-json": "^3.5.0",
     "jest": "^26.0.0",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "yarn install && yarn run css && webpack --mode production",
     "watch": "yarn install && yarn run css && webpack --watch --progress --colors",
     "css": "mkdir -p src/static/build && cp node_modules/@kbase/base-css/css/tachyons.min.css src/static/build/tachyons.min.css",
-    "fix": "prettier --write \"src/client/**/*.ts*\" && prettier --write \"test/**/*.ts*\""
+    "fix": "prettier --write \"src/client/**/*.ts*\""
   },
   "license": "MIT",
   "devDependencies": {

--- a/src/client/api/__tests__/iconProvider.spec.ts
+++ b/src/client/api/__tests__/iconProvider.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import iconData from '../../../src/client/api/icons.json';
+import iconData from '../icons.json';
 
 import IconProvider, {
   IconInfo,
   AppTag,
-} from '../../../src/client/api/iconProvider';
+} from '../iconProvider';
 const ip = IconProvider.Instance;
 const defaultType = {
   isImage: false,

--- a/src/client/api/__tests__/iconProvider.spec.ts
+++ b/src/client/api/__tests__/iconProvider.spec.ts
@@ -3,10 +3,7 @@
  */
 import iconData from '../icons.json';
 
-import IconProvider, {
-  IconInfo,
-  AppTag,
-} from '../iconProvider';
+import IconProvider, { IconInfo, AppTag } from '../iconProvider';
 const ip = IconProvider.Instance;
 const defaultType = {
   isImage: false,

--- a/src/client/components/generic/FilterDropdown.tsx
+++ b/src/client/components/generic/FilterDropdown.tsx
@@ -122,7 +122,7 @@ export class FilterDropdown extends Component<Props, State> {
 
   render() {
     const { items } = this.props;
-    let dropdownItems;
+    let dropdownItems = null;
     let selected = null;
     selected = items[this.state.selectedIdx];
     if (this.state.isOpen) {
@@ -140,10 +140,6 @@ export class FilterDropdown extends Component<Props, State> {
           {items.map((item, idx) => this.itemView(item, idx))}
         </div>
       );
-    } else {
-      dropdownItems = (
-        <div></div> // display: none?
-      );
     }
     const iconClass =
       'ml1 fa ' + (this.state.isOpen ? 'fa-caret-up' : 'fa-caret-down');
@@ -156,7 +152,7 @@ export class FilterDropdown extends Component<Props, State> {
           {this.props.txt + ': ' + selected}
           <i className={iconClass}></i>
         </a>
-        {dropdownItems}{' '}
+        {dropdownItems}
       </div>
     );
   }

--- a/src/client/components/generic/__tests__/DashboardButton.spec.tsx
+++ b/src/client/components/generic/__tests__/DashboardButton.spec.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import DashboardButton from '../DashboardButton';
+
+test('DashboardButton renders', () => {
+  const btn = shallow(<DashboardButton>foo</DashboardButton>);
+  expect(btn.text()).toEqual('foo');
+  expect(btn.hasClass('pointer')).toBeTruthy();
+  expect(btn.hasClass('dim')).toBeTruthy();
+  expect(btn.hasClass('not-allowed')).toBeFalsy();
+});
+
+test('DashboardButton can be disabled', () => {
+  const btn = shallow(<DashboardButton disabled={true}>bar</DashboardButton>);
+  expect(btn.prop('style')).toHaveProperty('cursor', 'not-allowed');
+});

--- a/src/client/components/generic/__tests__/FilterDropdown.spec.tsx
+++ b/src/client/components/generic/__tests__/FilterDropdown.spec.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-
 import React from 'react';
 import { shallow, render, mount } from 'enzyme';
 import { FilterDropdown } from '../FilterDropdown';
@@ -31,35 +30,37 @@ test('Filterdropdown should expand and collapse as expected', () => {
 });
 
 test('FilterDropdown should start with showing its options with the isOpen prop', () => {
-    const dropdown = mount(
-        <FilterDropdown
-            onSelect={(idx, val) => {}}
-            txt={'text'}
-            items={['item1', 'item2']}
-            isOpen={true}
-        />
-    );
-    expect(dropdown.find('div.shadow-3').children().length).toEqual(2);
+  const dropdown = mount(
+    <FilterDropdown
+      onSelect={(idx, val) => {}}
+      txt={'text'}
+      items={['item1', 'item2']}
+      isOpen={true}
+    />
+  );
+  expect(dropdown.find('div.shadow-3').children().length).toEqual(2);
 });
 
 test('FilterDropdown should close on document click', () => {
-    const wrapper = mount(
-        <FilterDropdown
-        onSelect={(idx, val) => {}}
-        txt={'text'}
-        items={['item1', 'item2']}
-        isOpen={true}
-        />
-    );
-    expect(wrapper.find('div.shadow-3').children().length).toEqual(2);
+  const wrapper = mount(
+    <FilterDropdown
+      onSelect={(idx, val) => {}}
+      txt={'text'}
+      items={['item1', 'item2']}
+      isOpen={true}
+    />
+  );
+  expect(wrapper.find('div.shadow-3').children().length).toEqual(2);
 
-    /* Noting here that this kinda skirts the outside of Enzyme's simulation.
-     * This click event does trigger the events set up in FilterDropdown
-     * but not through Enzyme, so it doesn't change the structure that Enzyme
-     * knows about, but it DOES change the rendered HTML.
-     * There's probably a better way to do this, involved with rewriting how
-     * that listener gets created, but I don't know what it is, and this works.
-     */
-    document.body.click();
-    expect(wrapper.find(FilterDropdown).html()).toEqual('<div class="dib relative"><a class="dim dib pa2 br2 ba b--solid b--black-20 pointer bg-white">text: item1<i class="ml1 fa fa-caret-down"></i></a></div>');
+  /* Noting here that this kinda skirts the outside of Enzyme's simulation.
+   * This click event does trigger the events set up in FilterDropdown
+   * but not through Enzyme, so it doesn't change the structure that Enzyme
+   * knows about, but it DOES change the rendered HTML.
+   * There's probably a better way to do this, involved with rewriting how
+   * that listener gets created, but I don't know what it is, and this works.
+   */
+  document.body.click();
+  expect(wrapper.find(FilterDropdown).html()).toEqual(
+    '<div class="dib relative"><a class="dim dib pa2 br2 ba b--solid b--black-20 pointer bg-white">text: item1<i class="ml1 fa fa-caret-down"></i></a></div>'
+  );
 });

--- a/src/client/components/generic/__tests__/FilterDropdown.spec.tsx
+++ b/src/client/components/generic/__tests__/FilterDropdown.spec.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+
+import React from 'react';
+import { shallow, render, mount } from 'enzyme';
+import { FilterDropdown } from '../FilterDropdown';
+import { doesNotReject } from 'assert';
+
+const dummyEvent = {
+  preventDefault: () => {},
+  type: 'mousedown',
+  button: 0,
+};
+
+test('Filterdropdown should expand and collapse as expected', () => {
+  const dropdown = mount(
+    <FilterDropdown
+      onSelect={(idx: number, val: string) => {}}
+      txt={'text'}
+      items={['item1', 'item2']}
+    />
+  );
+  expect(dropdown.childAt(0).children().length).toEqual(1);
+  dropdown.find('a.dim.dib').simulate('click', dummyEvent);
+  expect(dropdown.childAt(0).children().length).toEqual(2);
+  expect(dropdown.find('div.shadow-3').children().length).toEqual(2);
+  dropdown.find('a.dim.dib').simulate('click', dummyEvent);
+  expect(dropdown.childAt(0).children().length).toEqual(1);
+});
+
+test('FilterDropdown should start with showing its options with the isOpen prop', () => {
+    const dropdown = mount(
+        <FilterDropdown
+            onSelect={(idx, val) => {}}
+            txt={'text'}
+            items={['item1', 'item2']}
+            isOpen={true}
+        />
+    );
+    expect(dropdown.find('div.shadow-3').children().length).toEqual(2);
+});
+
+test('FilterDropdown should close on document click', () => {
+    const wrapper = mount(
+        <FilterDropdown
+        onSelect={(idx, val) => {}}
+        txt={'text'}
+        items={['item1', 'item2']}
+        isOpen={true}
+        />
+    );
+    expect(wrapper.find('div.shadow-3').children().length).toEqual(2);
+
+    /* Noting here that this kinda skirts the outside of Enzyme's simulation.
+     * This click event does trigger the events set up in FilterDropdown
+     * but not through Enzyme, so it doesn't change the structure that Enzyme
+     * knows about, but it DOES change the rendered HTML.
+     * There's probably a better way to do this, involved with rewriting how
+     * that listener gets created, but I don't know what it is, and this works.
+     */
+    document.body.click();
+    expect(wrapper.find(FilterDropdown).html()).toEqual('<div class="dib relative"><a class="dim dib pa2 br2 ba b--solid b--black-20 pointer bg-white">text: item1<i class="ml1 fa fa-caret-down"></i></a></div>');
+});

--- a/src/client/components/generic/__tests__/LoadingSpinner.spec.tsx
+++ b/src/client/components/generic/__tests__/LoadingSpinner.spec.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow, render } from 'enzyme';
+import { LoadingSpinner } from '../LoadingSpinner';
+
+test('Loading spinner returns an empty element if loading is false', () => {
+  const elem = shallow(<LoadingSpinner loading={false} />);
+  expect(elem.html()).toBeFalsy(); // should be an empty string or null, whatever the renderer wants
+});
+
+test('Loading spinner should render correctly when loading', () => {
+  const elem = shallow(<LoadingSpinner loading={true} />);
+  expect(elem.find('i').hasClass('fa fa-gear fa-spin')).toBeTruthy();
+});

--- a/src/client/utils/__tests__/auth.spec.ts
+++ b/src/client/utils/__tests__/auth.spec.ts
@@ -2,12 +2,7 @@
  * @jest-environment jsdom
  */
 import { enableFetchMocks } from 'jest-fetch-mock';
-import {
-  getToken,
-  getUsername,
-  getUsernames,
-  searchUsernames,
-} from '../auth';
+import { getToken, getUsername, getUsernames, searchUsernames } from '../auth';
 enableFetchMocks();
 
 const token = 'someAuthToken';

--- a/src/client/utils/__tests__/auth.spec.ts
+++ b/src/client/utils/__tests__/auth.spec.ts
@@ -7,7 +7,7 @@ import {
   getUsername,
   getUsernames,
   searchUsernames,
-} from '../../../src/client/utils/auth';
+} from '../auth';
 enableFetchMocks();
 
 const token = 'someAuthToken';

--- a/src/client/utils/__tests__/cookies.spec.ts
+++ b/src/client/utils/__tests__/cookies.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { getCookie, removeCookie } from '../../../src/client/utils/cookies';
+import { getCookie, removeCookie } from '../cookies';
 
 describe('cookie tests', () => {
   const cookieName = 'some_cookie';

--- a/src/client/utils/__tests__/fetchApps.spec.ts
+++ b/src/client/utils/__tests__/fetchApps.spec.ts
@@ -6,8 +6,8 @@
 
 import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
-import { fetchApps } from '../../../src/client/utils/fetchApps';
-import Runtime from '../../../src/client/utils/runtime';
+import { fetchApps } from '../fetchApps';
+import Runtime from '../runtime';
 
 describe('fetchApps tests', () => {
   beforeEach(() => {});

--- a/src/client/utils/__tests__/narrativeData.spec.ts
+++ b/src/client/utils/__tests__/narrativeData.spec.ts
@@ -3,51 +3,53 @@
  */
 import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
-import {fetchNarrative, getCurrentUserPermission} from '../narrativeData';
+import { fetchNarrative, getCurrentUserPermission } from '../narrativeData';
 
 describe('narrativeData tests', () => {
-    const mockWSGetObjects2Ok = (narr: object) => {
-        fetchMock.mockOnce(async (req) => {
-            return JSON.stringify({
-                id: '12345',
-                version: '1.1',
-                result: [narr]
-            });
-        });
-    }
-
-    const mockGetPermissionsMassOk = (perms: {[key: string]: string}) => {
-        fetchMock.mockOnce(async (req) => {
-            return JSON.stringify({
-                id: '12345',
-                version: '1.1',
-                result: [{
-                    perms: [perms]
-                }]
-            });
-        });
-    }
-
-    it('Should return a narrative with the happy case', async () => {
-        const dummyNarr = {
-            data: {narr: 'obj'}
-        };
-        mockWSGetObjects2Ok(dummyNarr);
-        const narrObj = await fetchNarrative('123/45/6');
-        expect(narrObj).toEqual(dummyNarr);
+  const mockWSGetObjects2Ok = (narr: object) => {
+    fetchMock.mockOnce(async req => {
+      return JSON.stringify({
+        id: '12345',
+        version: '1.1',
+        result: [narr],
+      });
     });
+  };
 
-    it('Should return a set of user permissions with the happy case', async () => {
-        const perms = {'some_user': 'a'};
-        mockGetPermissionsMassOk(perms);
-        const fetchedPerms = await getCurrentUserPermission(123);
-        expect(fetchedPerms).toBe('a');
+  const mockGetPermissionsMassOk = (perms: { [key: string]: string }) => {
+    fetchMock.mockOnce(async req => {
+      return JSON.stringify({
+        id: '12345',
+        version: '1.1',
+        result: [
+          {
+            perms: [perms],
+          },
+        ],
+      });
     });
+  };
 
-    it('Should return a default of no access when user permissions are not defined', async () => {
-        const perms = {'other_user': 'a', 'yet_another_user': 'w'};
-        mockGetPermissionsMassOk(perms);
-        const fetchedPerms = await getCurrentUserPermission(123);
-        expect(fetchedPerms).toBe('n');
-    });
+  it('Should return a narrative with the happy case', async () => {
+    const dummyNarr = {
+      data: { narr: 'obj' },
+    };
+    mockWSGetObjects2Ok(dummyNarr);
+    const narrObj = await fetchNarrative('123/45/6');
+    expect(narrObj).toEqual(dummyNarr);
+  });
+
+  it('Should return a set of user permissions with the happy case', async () => {
+    const perms = { some_user: 'a' };
+    mockGetPermissionsMassOk(perms);
+    const fetchedPerms = await getCurrentUserPermission(123);
+    expect(fetchedPerms).toBe('a');
+  });
+
+  it('Should return a default of no access when user permissions are not defined', async () => {
+    const perms = { other_user: 'a', yet_another_user: 'w' };
+    mockGetPermissionsMassOk(perms);
+    const fetchedPerms = await getCurrentUserPermission(123);
+    expect(fetchedPerms).toBe('n');
+  });
 });

--- a/src/client/utils/__tests__/narrativeData.spec.ts
+++ b/src/client/utils/__tests__/narrativeData.spec.ts
@@ -3,7 +3,7 @@
  */
 import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
-import {fetchNarrative, getCurrentUserPermission} from '../../../src/client/utils/narrativeData';
+import {fetchNarrative, getCurrentUserPermission} from '../narrativeData';
 
 describe('narrativeData tests', () => {
     const mockWSGetObjects2Ok = (narr: object) => {

--- a/src/client/utils/__tests__/orgInfo.spec.ts
+++ b/src/client/utils/__tests__/orgInfo.spec.ts
@@ -7,7 +7,7 @@ import {
   getLinkedOrgs,
   lookupUserOrgs,
   linkNarrativeToOrg,
-} from '../../../src/client/utils/orgInfo';
+} from '../orgInfo';
 
 describe('Organizations API testing', () => {
   const authToken = 'someToken';

--- a/src/client/utils/__tests__/orgInfo.spec.ts
+++ b/src/client/utils/__tests__/orgInfo.spec.ts
@@ -3,11 +3,7 @@
  */
 import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
-import {
-  getLinkedOrgs,
-  lookupUserOrgs,
-  linkNarrativeToOrg,
-} from '../orgInfo';
+import { getLinkedOrgs, lookupUserOrgs, linkNarrativeToOrg } from '../orgInfo';
 
 describe('Organizations API testing', () => {
   const authToken = 'someToken';

--- a/src/client/utils/__tests__/readableDate.spec.ts
+++ b/src/client/utils/__tests__/readableDate.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { readableDate } from '../../../src/client/utils/readableDate';
+import { readableDate } from '../readableDate';
 
 const happyCases = [
   ['2020-05-01T20:56:05+0000', '5/1/2020'],

--- a/src/client/utils/__tests__/searchNarratives.spec.ts
+++ b/src/client/utils/__tests__/searchNarratives.spec.ts
@@ -21,34 +21,34 @@ const TEST_USER = 'some_user';
  * @param first int, the first id / name / etc in the list of narratives
  * @param count the total number of narratives to return
  */
-function fakeNarratives (owner: string, first: number, count: number) {
-    const docs = [];
-    for (let id=first; id<count+first; id++) {
-        docs.push({
-            id: `WS:${id}:1`,
-            index: 'narrative_1',
-            doc: {
-                access_group: id,
-                cells: [],
-                creation_date: "2020-07-17T22:04:00+0000",
-                creator: owner,
-                data_objects: [],
-                is_public: false,
-                narrative_title: `Narrative #${id}`,
-                obj_id: 1,
-                obj_name: `Narrative.${id}`,
-                obj_type_module: 'KBaseNarrative',
-                obj_type_name: 'Narrative',
-                obj_type_version: '4.0',
-                shared_users: [owner],
-                tags: ['narrative'],
-                timestamp: 1595023480707,
-                total_cells: 1,
-                version: 1
-            }
-        });
-    }
-    return docs;
+function fakeNarratives(owner: string, first: number, count: number) {
+  const docs = [];
+  for (let id = first; id < count + first; id++) {
+    docs.push({
+      id: `WS:${id}:1`,
+      index: 'narrative_1',
+      doc: {
+        access_group: id,
+        cells: [],
+        creation_date: '2020-07-17T22:04:00+0000',
+        creator: owner,
+        data_objects: [],
+        is_public: false,
+        narrative_title: `Narrative #${id}`,
+        obj_id: 1,
+        obj_name: `Narrative.${id}`,
+        obj_type_module: 'KBaseNarrative',
+        obj_type_name: 'Narrative',
+        obj_type_version: '4.0',
+        shared_users: [owner],
+        tags: ['narrative'],
+        timestamp: 1595023480707,
+        total_cells: 1,
+        version: 1,
+      },
+    });
+  }
+  return docs;
 }
 
 /**
@@ -56,209 +56,311 @@ function fakeNarratives (owner: string, first: number, count: number) {
  * the auth token (if needed) is valid.
  * @param param0 SearchParams - should be same as passed to searchNarratives
  */
-function mockSearchOk ({
-    term,
-    sort,
-    category,
-    skip,
-    pageSize
-}: SearchParams, owner: string) {
-    // mock should return up to the page size requested.
-    // use a fake list of narratives.
-    fetchMock.mockResponse(async (req) => {
-        const authHeader = req.headers.get('Authorization');
-        const reqBody = await req.json();
-        let isPublic = false;
-        const musts = reqBody.params.query.bool.must;
-        const publicTerm = musts.find((m: any) => {
-            return ('term' in m && 'is_public' in m.term)
-        });
-        if (publicTerm) {
-            isPublic = publicTerm.term.is_public;
-        }
-        const response = {
+function mockSearchOk(
+  { term, sort, category, skip, pageSize }: SearchParams,
+  owner: string
+) {
+  // mock should return up to the page size requested.
+  // use a fake list of narratives.
+  fetchMock.mockResponse(async req => {
+    const authHeader = req.headers.get('Authorization');
+    const reqBody = await req.json();
+    let isPublic = false;
+    const musts = reqBody.params.query.bool.must;
+    const publicTerm = musts.find((m: any) => {
+      return 'term' in m && 'is_public' in m.term;
+    });
+    if (publicTerm) {
+      isPublic = publicTerm.term.is_public;
+    }
+    const response = {
+      jsonrpc: '2.0',
+      id: '12345',
+      result: {
+        count: pageSize,
+        search_time: 1,
+        aggregations: {},
+        hits: fakeNarratives(owner, skip, pageSize),
+      },
+    };
+
+    if (authHeader === VALID_TOKEN) {
+      return JSON.stringify(response);
+    } else {
+      if (isPublic) {
+        return JSON.stringify(response);
+      } else {
+        return {
+          body: JSON.stringify({
             jsonrpc: '2.0',
             id: '12345',
-            result: {
-                count: pageSize,
-                search_time: 1,
-                aggregations: {},
-                hits: fakeNarratives(owner, skip, pageSize)
-            }
+            error: {
+              code: -32000,
+              message: 'WS token validation error',
+              data: {
+                class: 'RuntimeError',
+              },
+            },
+          }),
+          status: 401,
         };
-
-        if (authHeader === VALID_TOKEN) {
-            return JSON.stringify(response);
-        }
-        else {
-            if (isPublic) {
-                return JSON.stringify(response);
-            }
-            else {
-                return {
-                    body: JSON.stringify({
-                        jsonrpc: '2.0',
-                        id: '12345',
-                        error: {
-                            code: -32000,
-                            message: 'WS token validation error',
-                            data: {
-                                class: 'RuntimeError'
-                            }
-                        }
-                    }),
-                    status: 401
-                };
-            }
-        }
-    });
+      }
+    }
+  });
 }
 
-function setValidToken () {
-    document.cookie = `kbase_session=${VALID_TOKEN}`;
+function setValidToken() {
+  document.cookie = `kbase_session=${VALID_TOKEN}`;
 }
 
-function setInvalidToken () {
-    document.cookie = `kbase_session=NOPE.`;
+function setInvalidToken() {
+  document.cookie = `kbase_session=NOPE.`;
 }
 
 describe('searchNarratives tests', () => {
-    afterEach(() => {
-        document.cookie='kbase_session=';
-    });
+  afterEach(() => {
+    document.cookie = 'kbase_session=';
+  });
 
-    it('searchNarratives should return own narratives', async () => {
-        /* mocking goes HERE */
-        // add token
-        // mock endpoint
-        setValidToken();
-        mockSearchOk({term: '', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        const results = await searchNarratives({
-            term: '', category: 'own', sort: 'Recently updated', skip: 0, pageSize: 10
-        });
-        expect(results.count).toEqual(10);
-        expect(results.count).toEqual(results.hits.length);
+  it('searchNarratives should return own narratives', async () => {
+    /* mocking goes HERE */
+    // add token
+    // mock endpoint
+    setValidToken();
+    mockSearchOk(
+      { term: '', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    const results = await searchNarratives({
+      term: '',
+      category: 'own',
+      sort: 'Recently updated',
+      skip: 0,
+      pageSize: 10,
     });
+    expect(results.count).toEqual(10);
+    expect(results.count).toEqual(results.hits.length);
+  });
 
-    it('searchNarratives should fail to return own narratives when a token is not present', async () => {
-        mockSearchOk({term: '', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        await expect(() => searchNarratives({
-            term: '', category: 'own', sort: 'Recently updated', skip: 0, pageSize: 10
-        })).rejects.toThrow();
+  it('searchNarratives should fail to return own narratives when a token is not present', async () => {
+    mockSearchOk(
+      { term: '', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    await expect(() =>
+      searchNarratives({
+        term: '',
+        category: 'own',
+        sort: 'Recently updated',
+        skip: 0,
+        pageSize: 10,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('searchNarratives should fail when a bad token is used', async () => {
+    setInvalidToken();
+    mockSearchOk(
+      { term: '', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    await expect(() =>
+      searchNarratives({
+        term: '',
+        category: 'own',
+        sort: 'Recently updated',
+        skip: 0,
+        pageSize: 10,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('searchNarratives should return an empty set if zero results are found', async () => {
+    setValidToken();
+    mockSearchOk(
+      { term: '', sort: '', category: '', skip: 0, pageSize: 0 },
+      TEST_USER
+    );
+    const results = await searchNarratives({
+      term: '',
+      category: 'own',
+      sort: 'Recently updated',
+      skip: 0,
+      pageSize: 10,
     });
+    expect(results.count).toEqual(0);
+    expect(results.hits).toEqual([]);
+  });
 
-    it('searchNarratives should fail when a bad token is used', async () => {
-        setInvalidToken();
-        mockSearchOk({term: '', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        await expect(() => searchNarratives({
-            term: '', category: 'own', sort: 'Recently updated', skip: 0, pageSize: 10
-        })).rejects.toThrow();
+  it('searchNarratives should return shared narratives', async () => {
+    setValidToken();
+    mockSearchOk(
+      { term: '', sort: '', category: 'shared', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    const results = await searchNarratives({
+      term: '',
+      category: 'shared',
+      sort: 'Recently updated',
+      skip: 0,
+      pageSize: 10,
     });
+    expect(results.count).toEqual(10);
+    expect(results.hits.length).toEqual(results.count);
+  });
 
-    it('searchNarratives should return an empty set if zero results are found', async () => {
-        setValidToken();
-        mockSearchOk({term: '', sort: '', category: '', skip: 0, pageSize: 0}, TEST_USER);
-        const results = await searchNarratives({
-            term: '', category: 'own', sort: 'Recently updated', skip: 0, pageSize: 10
-        });
-        expect(results.count).toEqual(0);
-        expect(results.hits).toEqual([]);
+  it('searchNarratives should fail to return shared narratives when a token is not present', async () => {
+    mockSearchOk(
+      { term: '', sort: '', category: 'shared', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    await expect(() =>
+      searchNarratives({
+        term: '',
+        category: 'shared',
+        sort: 'Recently updated',
+        skip: 0,
+        pageSize: 10,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('searchNarratives should return public narratives', async () => {
+    setValidToken();
+    mockSearchOk(
+      { term: '', sort: '', category: 'public', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    const results = await searchNarratives({
+      term: '',
+      category: 'public',
+      sort: 'Recently updated',
+      skip: 0,
+      pageSize: 10,
     });
+    expect(results.count).toEqual(10);
+    expect(results.hits.length).toEqual(results.count);
+  });
 
-    it('searchNarratives should return shared narratives', async () => {
-        setValidToken();
-        mockSearchOk({term: '', sort: '', category: 'shared', skip: 0, pageSize: 10}, TEST_USER);
-        const results = await searchNarratives({
-            term: '', category: 'shared', sort: 'Recently updated', skip: 0, pageSize: 10
-        });
-        expect(results.count).toEqual(10);
-        expect(results.hits.length).toEqual(results.count);
+  it('searchNarratives should return tutorial narratives', async () => {
+    setValidToken();
+    mockSearchOk(
+      { term: '', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    const results = await searchNarratives({
+      term: '',
+      category: 'tutorials',
+      sort: 'Recently updated',
+      skip: 0,
+      pageSize: 10,
     });
+    expect(results.count).toEqual(10);
+    expect(results.hits.length).toEqual(results.count);
+  });
 
-    it('searchNarratives should fail to return shared narratives when a token is not present', async () => {
-        mockSearchOk({term: '', sort: '', category: 'shared', skip: 0, pageSize: 10}, TEST_USER);
-        await expect(() => searchNarratives({
-            term: '', category: 'shared', sort: 'Recently updated', skip: 0, pageSize: 10
-        })).rejects.toThrow();
+  it('searchNarratives should return tutorials or public narratives without auth', async () => {
+    mockSearchOk(
+      { term: '', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    const results = await searchNarratives({
+      term: '',
+      category: 'tutorials',
+      sort: 'Recently updated',
+      skip: 0,
+      pageSize: 10,
     });
+    expect(results.count).toEqual(10);
+    expect(results.hits.length).toEqual(results.count);
+  });
 
-    it('searchNarratives should return public narratives', async () => {
-        setValidToken();
-        mockSearchOk({term: '', sort: '', category: 'public', skip: 0, pageSize: 10}, TEST_USER);
-        const results = await searchNarratives({
-            term: '', category: 'public', sort: 'Recently updated', skip: 0, pageSize: 10
-        });
-        expect(results.count).toEqual(10);
-        expect(results.hits.length).toEqual(results.count);
-
+  it('searchNarratives should return a subset of narratives when searching by title', async () => {
+    setValidToken();
+    mockSearchOk(
+      { term: 'narr', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    const results = await searchNarratives({
+      term: 'narr',
+      category: 'tutorials',
+      sort: 'Recently updated',
+      skip: 0,
+      pageSize: 10,
     });
+    expect(results.count).toEqual(10);
+    expect(results.hits.length).toEqual(results.count);
+  });
 
-    it('searchNarratives should return tutorial narratives', async () => {
-        setValidToken();
-        mockSearchOk({term: '', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        const results = await searchNarratives({
-            term: '', category: 'tutorials', sort: 'Recently updated', skip: 0, pageSize: 10
-        });
-        expect(results.count).toEqual(10);
-        expect(results.hits.length).toEqual(results.count);
-    });
+  it('searchNarratives should sort results automatically by some criteria', async () => {
+    const sortings = [
+      'Recently created',
+      'Oldest',
+      'Least recently updated',
+      'Recently updated',
+    ];
+    mockSearchOk(
+      { term: 'narr', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    for (const s of sortings) {
+      const results = await searchNarratives({
+        term: '',
+        category: 'tutorials',
+        sort: s,
+        skip: 0,
+        pageSize: 10,
+      });
+      expect(results.count).toEqual(10);
+      expect(results.hits.length).toEqual(results.count);
+    }
+  });
 
-    it('searchNarratives should return tutorials or public narratives without auth', async () => {
-        mockSearchOk({term: '', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        const results = await searchNarratives({
-            term: '', category: 'tutorials', sort: 'Recently updated', skip: 0, pageSize: 10
-        });
-        expect(results.count).toEqual(10);
-        expect(results.hits.length).toEqual(results.count);
-    });
+  it('searchNarratives should fail on a bad sort request', async () => {
+    mockSearchOk(
+      { term: 'narr', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    await expect(() =>
+      searchNarratives({
+        term: '',
+        category: 'public',
+        sort: 'out_of_sorts',
+        skip: 0,
+        pageSize: 10,
+      })
+    ).rejects.toThrow();
+  });
 
-    it('searchNarratives should return a subset of narratives when searching by title', async () => {
-        setValidToken();
-        mockSearchOk({term: 'narr', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        const results = await searchNarratives({
-            term: 'narr', category: 'tutorials', sort: 'Recently updated', skip: 0, pageSize: 10
-        });
-        expect(results.count).toEqual(10);
-        expect(results.hits.length).toEqual(results.count);
-    });
+  it('searchNarratives should fail on a bad search category', async () => {
+    mockSearchOk(
+      { term: 'narr', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    await expect(() =>
+      searchNarratives({
+        term: '',
+        category: 'uncategorized',
+        sort: 'Recently updated',
+        skip: 0,
+        pageSize: 10,
+      })
+    ).rejects.toThrow();
+  });
 
-    it('searchNarratives should sort results automatically by some criteria', async () => {
-        const sortings = [
-            'Recently created',
-            'Oldest',
-            'Least recently updated',
-            'Recently updated'
-        ];
-        mockSearchOk({term: 'narr', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        for (const s of sortings) {
-            const results = await searchNarratives({
-                term: '', category: 'tutorials', sort: s, skip: 0, pageSize: 10
-            });
-            expect(results.count).toEqual(10);
-            expect(results.hits.length).toEqual(results.count);
-        }
+  it('searchNarratives should skip documents on request', async () => {
+    mockSearchOk(
+      { term: '', sort: '', category: '', skip: 0, pageSize: 10 },
+      TEST_USER
+    );
+    const results = await searchNarratives({
+      term: '',
+      category: 'public',
+      sort: 'Recently updated',
+      skip: 5,
+      pageSize: 10,
     });
-
-    it('searchNarratives should fail on a bad sort request', async () => {
-        mockSearchOk({term: 'narr', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        await expect(() => searchNarratives({
-            term: '', category: 'public', sort: 'out_of_sorts', skip: 0, pageSize: 10
-        })).rejects.toThrow();
-    });
-
-    it('searchNarratives should fail on a bad search category', async () => {
-        mockSearchOk({term: 'narr', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        await expect(() => searchNarratives({
-            term: '', category: 'uncategorized', sort: 'Recently updated', skip: 0, pageSize: 10
-        })).rejects.toThrow();
-    });
-
-    it('searchNarratives should skip documents on request', async () => {
-        mockSearchOk({term: '', sort: '', category: '', skip: 0, pageSize: 10}, TEST_USER);
-        const results = await searchNarratives({
-            term: '', category: 'public', sort: 'Recently updated', skip: 5, pageSize: 10
-        });
-        expect(results.count).toEqual(10);
-        expect(results.hits.length).toEqual(results.count);
-    });
+    expect(results.count).toEqual(10);
+    expect(results.hits.length).toEqual(results.count);
+  });
 });

--- a/src/client/utils/__tests__/searchNarratives.spec.ts
+++ b/src/client/utils/__tests__/searchNarratives.spec.ts
@@ -10,7 +10,7 @@
  */
 import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
-import searchNarratives, { SearchParams } from '../../../src/client/utils/searchNarratives';
+import searchNarratives, { SearchParams } from '../searchNarratives';
 
 const VALID_TOKEN = 'some_valid_token';
 const TEST_USER = 'some_user';
@@ -21,7 +21,7 @@ const TEST_USER = 'some_user';
  * @param first int, the first id / name / etc in the list of narratives
  * @param count the total number of narratives to return
  */
-const fakeNarratives = (owner: string, first: number, count: number) => {
+function fakeNarratives (owner: string, first: number, count: number) {
     const docs = [];
     for (let id=first; id<count+first; id++) {
         docs.push({
@@ -56,13 +56,13 @@ const fakeNarratives = (owner: string, first: number, count: number) => {
  * the auth token (if needed) is valid.
  * @param param0 SearchParams - should be same as passed to searchNarratives
  */
-const mockSearchOk = ({
+function mockSearchOk ({
     term,
     sort,
     category,
     skip,
     pageSize
-}: SearchParams, owner: string) => {
+}: SearchParams, owner: string) {
     // mock should return up to the page size requested.
     // use a fake list of narratives.
     fetchMock.mockResponse(async (req) => {
@@ -114,11 +114,11 @@ const mockSearchOk = ({
     });
 }
 
-const setValidToken = () => {
+function setValidToken () {
     document.cookie = `kbase_session=${VALID_TOKEN}`;
 }
 
-const setInvalidToken = () => {
+function setInvalidToken () {
     document.cookie = `kbase_session=NOPE.`;
 }
 

--- a/src/client/utils/__tests__/sortBy.spec.ts
+++ b/src/client/utils/__tests__/sortBy.spec.ts
@@ -1,4 +1,4 @@
-import { sortBy } from '../../../src/client/utils/sortBy';
+import { sortBy } from '../sortBy';
 
 test('sortBy should work for a simple number array', () => {
   const disordered = [3, 2, 1, 4, 6, 5];

--- a/src/client/utils/__tests__/stringUtils.spec.ts
+++ b/src/client/utils/__tests__/stringUtils.spec.ts
@@ -5,7 +5,7 @@
 import {
   formatSnakeCase,
   getWSTypeName,
-} from '../../../src/client/utils/stringUtils';
+} from '../stringUtils';
 
 test('formatSnakeCase should alter snakey strings', () => {
   const testStr = 'some_test_string';

--- a/src/client/utils/__tests__/stringUtils.spec.ts
+++ b/src/client/utils/__tests__/stringUtils.spec.ts
@@ -2,10 +2,7 @@
  * @jest-environment jsdom
  */
 
-import {
-  formatSnakeCase,
-  getWSTypeName,
-} from '../stringUtils';
+import { formatSnakeCase, getWSTypeName } from '../stringUtils';
 
 test('formatSnakeCase should alter snakey strings', () => {
   const testStr = 'some_test_string';

--- a/src/client/utils/__tests__/userInfo.spec.ts
+++ b/src/client/utils/__tests__/userInfo.spec.ts
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 import { enableFetchMocks } from 'jest-fetch-mock';
-import { fetchProfileAPI } from '../../../src/client/utils/userInfo';
-jest.mock('../../../src/client/api/serviceWizard');
+import { fetchProfileAPI } from '../userInfo';
+jest.mock('../../api/serviceWizard');
 enableFetchMocks();
 
 describe('fetchProfile tests', () => {

--- a/src/client/utils/searchNarratives.ts
+++ b/src/client/utils/searchNarratives.ts
@@ -96,12 +96,12 @@ export default async function searchNarratives({
   }
   switch (category) {
     case 'own':
-      musts.push({ term: { creator: Runtime.username() }});
+      musts.push({ term: { creator: Runtime.username() } });
       options.auth = true;
       break;
     case 'shared':
-      musts.push({ term: { shared_users: Runtime.username() }});
-      mustNots.push({ term: { creator: Runtime.username() }});
+      musts.push({ term: { shared_users: Runtime.username() } });
+      mustNots.push({ term: { creator: Runtime.username() } });
       options.auth = true;
       break;
     case 'public':
@@ -165,7 +165,9 @@ async function makeRequest({
   if (auth) {
     const token = getToken();
     if (!token) {
-      throw new Error('Auth token not available for an authenticated search lookup!')
+      throw new Error(
+        'Auth token not available for an authenticated search lookup!'
+      );
     }
     Object.assign(headers, { Authorization: token });
   }
@@ -182,7 +184,7 @@ async function makeRequest({
   const result = await fetch(Runtime.getConfig().service_routes.search, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ method: 'search_objects', params })
+    body: JSON.stringify({ method: 'search_objects', params }),
   });
   if (!result.ok) {
     throw new Error('An error occurred while searching - ' + result.status);

--- a/src/setupEnzyme.ts
+++ b/src/setupEnzyme.ts
@@ -1,0 +1,3 @@
+import { configure } from 'enzyme';
+import EnzymeAdapter from 'enzyme-adapter-react-16';
+configure({ adapter: new EnzymeAdapter() });

--- a/test/unit/utils/searchNarratives.spec.ts
+++ b/test/unit/utils/searchNarratives.spec.ts
@@ -51,12 +51,6 @@ const fakeNarratives = (owner: string, first: number, count: number) => {
     return docs;
 }
 
-const fakeHits = () => {
-
-}
-
-
-
 /**
  * This mocks doing the search in the happy case. Assumes no errors and that
  * the auth token (if needed) is valid.
@@ -117,15 +111,6 @@ const mockSearchOk = ({
                 };
             }
         }
-    });
-}
-
-const mockSearchBadAuth = () => {
-    fetchMock.mockResponse(async () => {
-        return {
-            body: JSON.stringify({}),
-            status: 401
-        };
     });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -628,10 +628,32 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cheerio@*":
+  version "0.22.21"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.21.tgz#5e37887de309ba11b2e19a6e14cad7874b31a8a3"
+  integrity sha512-aGI3DfswwqgKPiEOTaiHV2ZPC9KEhprpgEbJnv0fZl3SGX0cGgEva1126dGrMC6AJM6v/aihlUgJn9M5DbDZ/Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/enzyme-adapter-react-16@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.6.tgz#8aca7ae2fd6c7137d869b6616e696d21bb8b0cec"
+  integrity sha512-VonDkZ15jzqDWL8mPFIQnnLtjwebuL9YnDkqeCDYnB4IVgwUm0mwKkqhrxLL6mb05xm7qqa3IE95m8CZE9imCg==
+  dependencies:
+    "@types/enzyme" "*"
+
+"@types/enzyme@*", "@types/enzyme@^3.10.5":
+  version "3.10.5"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.5.tgz#fe7eeba3550369eed20e7fb565bfb74eec44f1f0"
+  integrity sha512-R+phe509UuUYy9Tk0YlSbipRpfVtIzb/9BHn5pTEtjJTF5LXvUjrIQcZvNyANNEyFrd2YGs196PniNT1fgvOQA==
+  dependencies:
+    "@types/cheerio" "*"
+    "@types/react" "*"
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
@@ -968,6 +990,21 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
   integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
 
+airbnb-prop-types@^2.15.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz#b96274cefa1abb14f623f804173ee97c13971dc2"
+  integrity sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==
+  dependencies:
+    array.prototype.find "^2.1.1"
+    function.prototype.name "^1.1.2"
+    is-regex "^1.1.0"
+    object-is "^1.1.2"
+    object.assign "^4.1.0"
+    object.entries "^1.1.2"
+    prop-types "^15.7.2"
+    prop-types-exact "^1.2.0"
+    react-is "^16.13.1"
+
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -1091,6 +1128,11 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-filter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
+  integrity sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -1100,6 +1142,22 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+array.prototype.find@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.1.1.tgz#3baca26108ca7affb08db06bf0be6cb3115a969c"
+  integrity sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.4"
+
+array.prototype.flat@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
+  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -1333,6 +1391,11 @@ body-parser@1.19.0:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1595,6 +1658,18 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
+cheerio@^1.0.0-rc.3:
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
+  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.1"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 chokidar@^2.0.2:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -1721,7 +1796,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.18.0, commander@^2.20.0:
+commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -1933,6 +2008,21 @@ css-loader@^3.2.0:
     postcss-value-parser "^4.0.0"
     schema-utils "^2.0.0"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
+  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -2037,6 +2127,13 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
+define-properties@^1.1.2, define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -2121,6 +2218,11 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
+
 dom-helpers@^5.0.1:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"
@@ -2129,10 +2231,36 @@ dom-helpers@^5.0.1:
     "@babel/runtime" "^7.8.7"
     csstype "^2.6.7"
 
+dom-serializer@0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
+dom-serializer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
+  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
+  dependencies:
+    domelementtype "^1.3.0"
+    entities "^1.1.1"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
+
+domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -2140,6 +2268,29 @@ domexception@^2.0.1:
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 duplexer@^0.1.1:
   version "0.1.1"
@@ -2232,6 +2383,87 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+entities@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+
+enzyme-adapter-react-16@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.2.tgz#b16db2f0ea424d58a808f9df86ab6212895a4501"
+  integrity sha512-SkvDrb8xU3lSxID8Qic9rB8pvevDbLybxPK6D/vW7PrT0s2Cl/zJYuXvsd1EBTz0q4o3iqG3FJhpYz3nUNpM2Q==
+  dependencies:
+    enzyme-adapter-utils "^1.13.0"
+    enzyme-shallow-equal "^1.0.1"
+    has "^1.0.3"
+    object.assign "^4.1.0"
+    object.values "^1.1.1"
+    prop-types "^15.7.2"
+    react-is "^16.12.0"
+    react-test-renderer "^16.0.0-0"
+    semver "^5.7.0"
+
+enzyme-adapter-utils@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.13.0.tgz#01c885dde2114b4690bf741f8dc94cee3060eb78"
+  integrity sha512-YuEtfQp76Lj5TG1NvtP2eGJnFKogk/zT70fyYHXK2j3v6CtuHqc8YmgH/vaiBfL8K1SgVVbQXtTcgQZFwzTVyQ==
+  dependencies:
+    airbnb-prop-types "^2.15.0"
+    function.prototype.name "^1.1.2"
+    object.assign "^4.1.0"
+    object.fromentries "^2.0.2"
+    prop-types "^15.7.2"
+    semver "^5.7.1"
+
+enzyme-shallow-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz#7afe03db3801c9b76de8440694096412a8d9d49e"
+  integrity sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==
+  dependencies:
+    has "^1.0.3"
+    object-is "^1.0.2"
+
+enzyme-to-json@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.5.0.tgz#3d536f1e8fb50d972360014fe2bd64e6a672f7dd"
+  integrity sha512-clusXRsiaQhG7+wtyc4t7MU8N3zCOgf4eY9+CeSenYzKlFST4lxerfOvnWd4SNaToKhkuba+w6m242YpQOS7eA==
+  dependencies:
+    lodash "^4.17.15"
+    react-is "^16.12.0"
+
+enzyme@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.11.0.tgz#71d680c580fe9349f6f5ac6c775bc3e6b7a79c28"
+  integrity sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==
+  dependencies:
+    array.prototype.flat "^1.2.3"
+    cheerio "^1.0.0-rc.3"
+    enzyme-shallow-equal "^1.0.1"
+    function.prototype.name "^1.1.2"
+    has "^1.0.3"
+    html-element-map "^1.2.0"
+    is-boolean-object "^1.0.1"
+    is-callable "^1.1.5"
+    is-number-object "^1.0.4"
+    is-regex "^1.0.5"
+    is-string "^1.0.5"
+    is-subset "^0.1.1"
+    lodash.escape "^4.0.1"
+    lodash.isequal "^4.5.0"
+    object-inspect "^1.7.0"
+    object-is "^1.0.2"
+    object.assign "^4.1.0"
+    object.entries "^1.1.1"
+    object.values "^1.1.1"
+    raf "^3.4.1"
+    rst-selector-parser "^2.2.3"
+    string.prototype.trim "^1.2.1"
+
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
@@ -2245,6 +2477,32 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.4, es-abstract@^1.17.5:
+  version "1.17.6"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
+  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.0"
+    is-regex "^1.1.0"
+    object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -2678,6 +2936,25 @@ fsevents@^2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+function.prototype.name@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.2.tgz#5cdf79d7c05db401591dfde83e3b70c5123e9a45"
+  integrity sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    functions-have-names "^1.2.0"
+
+functions-have-names@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.1.tgz#a981ac397fa0c9964551402cdc5533d7a4d52f91"
+  integrity sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -2835,6 +3112,11 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-symbols@^1.0.0, has-symbols@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2870,6 +3152,13 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^3.0.0:
   version "3.0.4"
@@ -2925,6 +3214,13 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
+html-element-map@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/html-element-map/-/html-element-map-1.2.0.tgz#dfbb09efe882806af63d990cf6db37993f099f22"
+  integrity sha512-0uXq8HsuG1v2TmQ8QkIhzbrqeskE4kn52Q18QJ9iAA/SnHoEKXWiUxHQtclRsCFWEUD2So34X+0+pZZu862nnw==
+  dependencies:
+    array-filter "^1.0.0"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -2936,6 +3232,18 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+htmlparser2@^3.9.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+  dependencies:
+    domelementtype "^1.3.1"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.1.1"
 
 http-errors@1.7.2:
   version "1.7.2"
@@ -3122,10 +3430,20 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-boolean-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.1.tgz#10edc0900dd127697a92f6f9807c7617d68ac48e"
+  integrity sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
+  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -3147,6 +3465,11 @@ is-data-descriptor@^1.0.0:
   integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
+  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -3224,6 +3547,11 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-number-object@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
+  integrity sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -3248,6 +3576,13 @@ is-potential-custom-element-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
 
+is-regex@^1.0.5, is-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
+  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
+  dependencies:
+    has-symbols "^1.0.1"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -3257,6 +3592,23 @@ is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
+is-string@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
+  integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+  integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
+
+is-symbol@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
+  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+  dependencies:
+    has-symbols "^1.0.1"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -3916,6 +4268,21 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.escape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
+  integrity sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=
+
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -3925,6 +4292,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash@^4.15.0:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
@@ -4212,6 +4584,11 @@ moment@^2.24.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.25.3.tgz#252ff41319cf41e47761a1a88cab30edfe9808c0"
   integrity sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg==
 
+moo@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
+  integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -4265,6 +4642,17 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+nearley@^2.7.10:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.19.5.tgz#6be78e4942eeb9a043b17c563413111d4ad849b7"
+  integrity sha512-qoh1ZXXl0Kpn40tFhmgvffUAlbpRMcjLUagNVnT1JmliUIsB4tFabmCNhD97+tkf9FZ/SLhhYzNow0V3GitzDg==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
 
 needle@^2.2.1:
   version "2.4.0"
@@ -4429,6 +4817,13 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -4458,6 +4853,24 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-inspect@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
+  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
+
+object-is@^1.0.2, object-is@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.2.tgz#c5d2e87ff9e119f78b7a088441519e2eec1573b6"
+  integrity sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
@@ -4465,12 +4878,51 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.entries@^1.1.1, object.entries@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
+  integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+    has "^1.0.3"
+
+object.fromentries@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.2.tgz#4a09c9b9bb3843dd0f89acdb517a794d4f355ac9"
+  integrity sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+
 object.pick@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+object.values@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz#68a99ecde356b7e9295a3c5e0ce31dc8c953de5e"
+  integrity sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -4640,6 +5092,13 @@ parse5@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.3:
   version "1.3.3"
@@ -4872,7 +5331,16 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types-exact@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
+  integrity sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==
+  dependencies:
+    has "^1.0.3"
+    object.assign "^4.1.0"
+    reflect.ownkeys "^0.2.0"
+
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -4971,6 +5439,26 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+raf@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -5028,7 +5516,7 @@ react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.12.0:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5051,6 +5539,16 @@ react-select@^3.1.0:
     prop-types "^15.6.0"
     react-input-autosize "^2.2.2"
     react-transition-group "^4.3.0"
+
+react-test-renderer@^16.0.0-0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
+  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.19.1"
 
 react-transition-group@^4.3.0:
   version "4.4.1"
@@ -5103,6 +5601,15 @@ read-pkg@^5.2.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.1.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -5111,6 +5618,11 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+reflect.ownkeys@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
+  integrity sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=
 
 regenerator-runtime@^0.13.2:
   version "0.13.3"
@@ -5278,6 +5790,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  integrity sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -5347,6 +5867,14 @@ scheduler@^0.17.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -5364,7 +5892,7 @@ schema-utils@^2.0.0, schema-utils@^2.0.1:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -5737,7 +6265,32 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string_decoder@^1.0.0:
+string.prototype.trim@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz#141233dff32c82bfad80684d7e5f0869ee0fb782"
+  integrity sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+
+string.prototype.trimend@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
+  integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+
+string.prototype.trimstart@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
+  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+
+string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
@@ -6189,7 +6742,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
Been reading about this, and just about all articles suggest keeping tests close to source code in a __tests__ subdirectory. It's also the Jest default config (or was, not too long ago).

I think it'll be helpful for organization at this point.