### PR TITLE
Fixed NarrativeList Load more button

### DIFF
--- a/src/client/components/dashboard/NarrativeList/ItemList.tsx
+++ b/src/client/components/dashboard/NarrativeList/ItemList.tsx
@@ -7,15 +7,15 @@ import { Doc } from '../../../utils/narrativeData';
 const timeago = require('timeago.js');
 
 interface Props {
+  category: string;
   items: Array<Doc>;
   loading: boolean;
-  totalItems: number;
-  onLoadMore?: () => void;
   onSelectItem?: (idx: number) => void;
-  selectedIdx: number;
-  category: string;
+  pageSize: number;
   selected: string;
+  selectedIdx: number;
   sort?: string;
+  totalItems: number;
 }
 
 interface State {}
@@ -41,13 +41,6 @@ export class ItemList extends Component<Props, State> {
     }
     if (this.props.onSelectItem) {
       this.props.onSelectItem(idx);
-    }
-  }
-
-  // Handle click event on the "load more" button
-  handleClickLoadMore(ev: React.MouseEvent) {
-    if (this.props.onLoadMore) {
-      this.props.onLoadMore();
     }
   }
 
@@ -96,7 +89,8 @@ export class ItemList extends Component<Props, State> {
   };
 
   hasMoreButton() {
-    const hasMore = this.props.items.length < this.props.totalItems;
+    const { items, pageSize, totalItems } = this.props;
+    const hasMore = items.length < totalItems;
     if (!hasMore) {
       return <span className="black-50 pa3 dib tc">No more results.</span>;
     }
@@ -108,13 +102,15 @@ export class ItemList extends Component<Props, State> {
         </span>
       );
     }
+    const keepParams = (link: string) =>
+      keepParamsLinkTo(['sort', 'view'], link);
     return (
-      <a
+      <Link
         className="tc pa3 dib pointer blue dim b"
-        onClick={(ev: React.MouseEvent) => this.handleClickLoadMore(ev)}
+        to={keepParams(`./?limit=${items.length + pageSize}`)}
       >
         Load more ({this.props.totalItems - this.props.items.length} remaining)
-      </a>
+      </Link>
     );
   }
 

--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -7,7 +7,7 @@ import SubTabs from '../../generic/SubTabs';
 import { Doc } from '../../../utils/narrativeData';
 import { readableDate } from '../../../utils/readableDate';
 import Runtime from '../../../utils/runtime';
-import { keepSort } from '../utils';
+import { keepParamsLinkTo } from '../utils';
 import ControlMenu from './ControlMenu/ControlMenu';
 import DataView from './DataView';
 import Preview from './Preview';
@@ -93,14 +93,16 @@ export const NarrativeDetails: React.FC<Props> = ({
       );
       break;
   }
+  const keepParams = (link: string) =>
+    keepParamsLinkTo(['limit', 'sort'], link);
   const tabs = Object.entries({
     data: {
       name: 'Data',
-      link: keepSort('?view=data'),
+      link: keepParams('?view=data'),
     },
     preview: {
       name: 'Preview',
-      link: keepSort('?view=preview'),
+      link: keepParams('?view=preview'),
     },
   });
   return (

--- a/src/client/components/dashboard/__tests__/utils.spec.ts
+++ b/src/client/components/dashboard/__tests__/utils.spec.ts
@@ -5,7 +5,7 @@
 // as of now eslint cannot detect when imported interfaces are used
 import { Location } from 'history'; // eslint-disable-line no-unused-vars
 
-import { keepParamsLinkTo, keepSort } from '../utils';
+import { keepParamsLinkTo } from '../utils';
 
 const mocks = (
   pathname: string = 'path',
@@ -73,10 +73,5 @@ describe('Dashboard utils tests', () => {
     expect(link).toBe(
       '/path/elsewhere?withThisParam=true&keepThisParam=1729&andThis=Ramanujan'
     );
-  });
-  test('keepSort keeps the sort parameter', () => {
-    const { mockHistoryLocation } = mocks('/path/', '?sort=up&notThis=false');
-    const link = keepSort('/')(mockHistoryLocation);
-    expect(link).toBe('/?sort=up');
   });
 });

--- a/src/client/components/dashboard/utils.ts
+++ b/src/client/components/dashboard/utils.ts
@@ -25,5 +25,3 @@ export const keepParamsLinkTo = (paramsToKeep: string[], link: string) => (
   });
   return newLink.pathname + newLink.search + newLink.hash;
 };
-
-export const keepSort = (link: string) => keepParamsLinkTo(['sort'], link);

--- a/src/client/components/global_header/Header.tsx
+++ b/src/client/components/global_header/Header.tsx
@@ -114,7 +114,11 @@ export class Header extends Component<Props, State> {
   // Set gravatarURL
   gravatarSrc() {
     if (this.state.avatarOption === 'silhoutte' || !this.state.gravatarHash) {
-      return '/static/images/nouserpic.png';
+      let origin = Runtime.getConfig().host_root;
+      if (origin !== location.origin) {
+        origin = '';
+      }
+      return origin + window._env.urlPrefix + '/static/images/nouserpic.png';
     } else if (this.state.gravatarHash) {
       return (
         'https://www.gravatar.com/avatar/' +

--- a/src/client/utils/__tests__/searchNarratives.spec.ts
+++ b/src/client/utils/__tests__/searchNarratives.spec.ts
@@ -25,7 +25,7 @@ const TEST_USER = 'some_user';
  * @param {number} count the total number of narratives to return
  * @return {array}
  */
-function fakeNarratives(owner: string, first: number, count: number) {
+function fakeNarratives(owner: string, first: number = 0, count: number) {
   const docs = [];
   for (let id = first; id < count + first; id++) {
     docs.push({

--- a/src/client/utils/searchNarratives.ts
+++ b/src/client/utils/searchNarratives.ts
@@ -8,7 +8,7 @@ export interface SearchOptions {
   term: string;
   sort: string;
   category: string;
-  skip: number;
+  skip?: number;
   pageSize: number;
   musts?: Array<any>;
   mustNots?: Array<any>;
@@ -130,7 +130,7 @@ export default async function searchNarratives({
     types: ['KBaseNarrative.Narrative'],
     paging: {
       length: pageSize,
-      offset: skip,
+      offset: skip || 0,
     },
     track_total_hits: false,
   };


### PR DESCRIPTION
This PR fixes the button for loading more items in the narrative list in situations where there is a prefix for the dashboard app. This is a common feature of KBase environments and can be dealt with in most cases by keeping links relative. Given that this approach means that the client URL will always reflect how many narratives the user wishes to see, the list can be derived entirely from the URL any time it updates. This eliminates the need for some component state management callbacks which have been removed. The default user picture is an example where absolute links are needed, so this update fixes these references in other environments as well.