### PR TITLE
Fixed SCT-2780, SCT-2781 and SCT-2782.

### DIFF
--- a/src/client/components/catalog/__tests__/AppCatalog.spec.tsx
+++ b/src/client/components/catalog/__tests__/AppCatalog.spec.tsx
@@ -4,9 +4,46 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-
+import { enableFetchMocks } from 'jest-fetch-mock';
 import { AppCatalog } from '../AppCatalog';
 
+enableFetchMocks();
+
 describe('AppCatalog tests', () => {
+  const mockCatalogResponse = {
+    version: '1.1',
+    result: [
+      [
+        {
+          full_app_id: 'KBaseRNASeq/describe_rnaseq_experiment',
+          module_name: 'KBaseRNASeq',
+          number_of_calls: 1017,
+          number_of_errors: 172,
+          time_range: '*',
+          total_exec_time: 53274.808003902435,
+          total_queue_time: 463746.8269994259,
+          type: 'a',
+        },
+      ],
+    ],
+  };
+  const mockNMSResponse = {
+    version: '1.1',
+    result: [[]],
+  };
+  fetchMock.mockIf(/services/, async req => {
+    if (req.url.endsWith('catalog')) {
+      return {
+        body: JSON.stringify(mockCatalogResponse),
+        status: 200,
+      };
+    } else if (req.url.includes('narrative_method_store')) {
+      return {
+        body: JSON.stringify(mockNMSResponse),
+        status: 200,
+      };
+    }
+    return { status: 404 };
+  });
   it('Should be callable', () => expect(shallow(<AppCatalog />)).toBeTruthy());
 });

--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -4,151 +4,19 @@ import React from 'react';
 import SubTabs from '../../generic/SubTabs';
 
 // Utils
-import { Doc } from '../../../utils/narrativeData';
+import { Doc, KBaseCache } from '../../../utils/narrativeData';
 import { readableDate } from '../../../utils/readableDate';
+import { fetchProfile, fetchProfiles } from '../../../utils/userInfo';
 import Runtime from '../../../utils/runtime';
 import { keepParamsLinkTo } from '../utils';
 import ControlMenu from './ControlMenu/ControlMenu';
 import DataView from './DataView';
 import Preview from './Preview';
 
-/**
- * Shows some basic details, specifically:
- *  - author (user id of owner)
- *  - total cells
- *  - visibility (public or private)
- *  - created date
- *  - data objects
- * @param {Doc} data - a representation of a narrative
- * @return {JSX}
- */
-const detailsHeader = (data: Doc) => {
-  const sharedWith = data.shared_users.filter(
-    (user: string) => user !== Runtime.username()
-  );
-  const cellTypeCounts = countCellTypes(data.cells);
-  /*
-  Convert the string names into a JSX array of arrays of commas and links,
-  flatten into a single array and finally slice off the first comma.
-  */
-  const separator = (key: String) => (
-    <React.Fragment key={`${key}-sep`}>, </React.Fragment>
-  ); // Turn a comma into a JSX element
-  const sharedWithLinks = sharedWith
-    .map((share: String) => [
-      separator(share),
-      <a key={`${share}-link`} href={`/#user/${share}`}>
-        {share}
-      </a>,
-    ])
-    .reduce((acc, elt) => acc.concat(elt), [])
-    .slice(1);
-  return (
-    <div className="flex flex-wrap f6 pb3">
-      {detailsHeaderItem('Author', data.creator)}
-      {detailsHeaderItem('Total cells', String(data.total_cells))}
-      {detailsHeaderItem('Visibility', data.is_public ? 'Public' : 'Private')}
-      {detailsHeaderItem('Created on', readableDate(data.creation_date))}
-      {detailsHeaderItem('Last saved', readableDate(data.timestamp))}
-      {detailsHeaderItem('Data objects', String(data.data_objects.length))}
-      {detailsHeaderItem('App cells', cellTypeCounts.kbase_app)}
-      {detailsHeaderItem('Markdown cells', cellTypeCounts.markdown)}
-      {detailsHeaderItem('Code Cells', cellTypeCounts.code_cell)}
-      {data.is_public || !sharedWith.length ? (
-        <></>
-      ) : (
-        detailsHeaderItem('Shared with', sharedWithLinks)
-      )}
-    </div>
-  );
-};
-
-interface Props {
-  activeItem: Doc;
-  updateSearch: () => void;
-  view: string;
-}
-
-// Narrative details side panel in the narrative listing.
-export const NarrativeDetails: React.FC<Props> = ({
-  activeItem,
-  updateSearch,
-  view,
-}) => {
-  if (!activeItem) {
-    return <div></div>;
-  }
-  const wsid = activeItem.access_group;
-  const narrativeHref = `${Runtime.getConfig().view_routes.narrative}/${wsid}`;
-  let content: JSX.Element | string = '';
-  // Choose which content to show based on selected tab
-  switch (view) {
-    case 'preview':
-      content = <Preview narrative={activeItem} />;
-      break;
-    case 'data':
-    default:
-      content = (
-        <DataView accessGroup={wsid} dataObjects={activeItem.data_objects} />
-      );
-      break;
-  }
-  const keepParams = (link: string) =>
-    keepParamsLinkTo(['limit', 'sort'], link);
-  const tabs = Object.entries({
-    data: {
-      name: 'Data',
-      link: keepParams('?view=data'),
-    },
-    preview: {
-      name: 'Preview',
-      link: keepParams('?view=preview'),
-    },
-  });
-  return (
-    <div
-      className="w-60 bg-white pv2 ph3 bt bb br b--black-20"
-      style={{
-        top: window._env.legacyNav ? '4rem' : '0.75rem',
-        position: 'sticky',
-      }}
-    >
-      <div className="flex justify-between mb3 ma0 pa0 pt2">
-        <div className="f3">
-          <a
-            className="blue pointer no-underline dim"
-            href={narrativeHref}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <span className="fa fa-external-link"></span>
-            <span className="ml2">
-              {activeItem.narrative_title || 'Untitled'}
-            </span>
-          </a>
-          <span className="b f4 gray i ml2">v{activeItem.version}</span>
-        </div>
-        <div className="ml-auto">
-          <ControlMenu
-            narrative={activeItem}
-            doneFn={() => {
-              updateSearch();
-            }}
-          />
-        </div>
-      </div>
-      <div>{detailsHeader(activeItem)}</div>
-
-      <SubTabs tabs={tabs} className="mb3" selected={view} />
-      {content}
-    </div>
-  );
-};
-
 function detailsHeaderItem(key: string, value: string | JSX.Element[]) {
   return (
-    <div className="w-third pv1">
-      {key}: <span className="b">{value}</span>
+    <div className="narrative-details-key">
+      {key}: <span className="narrative-details-value">{value}</span>
     </div>
   );
 }
@@ -165,4 +33,270 @@ function countCellTypes(cells: any[]): any {
     acc[cell.cell_type] += 1;
     return acc;
   }, defaults);
+}
+
+function countDataTypes(data: any) {
+  const counts: Record<string, number> = {};
+  const normalize = (key: any) => {
+    const begin = key.indexOf('.') + 1;
+    const end = key.lastIndexOf('-');
+    return key.slice(begin, end);
+  };
+  const sortCountDesc = (freq1: [string, number], freq2: [string, number]) => {
+    const count1 = freq1[1];
+    const count2 = freq2[1];
+    return -1 + +(count1 === count2) + 2 * +(count1 < count2);
+  };
+  data.data_objects.forEach((obj: any) => {
+    const key = normalize(obj.obj_type);
+    if (!(key in counts)) {
+      counts[key] = 0;
+    }
+    counts[key] = counts[key] + 1;
+  });
+  const dataPlaces = Object.entries(counts)
+    .sort(sortCountDesc)
+    .slice(0, 3);
+  const out = [<></>, <></>, <></>];
+  return out.map((el, ix) => {
+    if (ix in dataPlaces) {
+      const [dataType, count] = dataPlaces[ix];
+      return detailsHeaderItem(dataType, count.toString());
+    }
+    return el;
+  });
+}
+
+const profileLink = (username: string, realname: string) => (
+  <a key={`${username}-link`} href={`/#user/${username}`} title={username}>
+    {realname}
+  </a>
+);
+
+const detailsSharedWith = (users: string[], profiles: any) => {
+  /*
+  Convert the string names into a JSX array of arrays of commas and links,
+  flatten into a single array and finally slice off the first comma.
+  */
+  const separator = (key: string) => (
+    <React.Fragment key={`${key}-sep`}>, </React.Fragment>
+  ); // Turn a comma into a JSX element
+  const sharedWithLinks = users
+    .map((share: string, ix: number) => {
+      let displayName = share;
+      if (profiles[ix]) {
+        displayName = profiles[ix].user.realname;
+      }
+      return [separator(share), profileLink(share, displayName)];
+    })
+    .reduce((acc, elt) => acc.concat(elt), [])
+    .slice(1);
+  const sharedFirst = sharedWithLinks.slice(0, 20);
+  const sharedRest = sharedWithLinks.slice(20);
+  let sharedRestDetails = <></>;
+  if (sharedRest.length > 0) {
+    sharedRestDetails = (
+      <>
+        <input
+          type="checkbox"
+          name="narrative-shared-status"
+          id="narrative-shared-status"
+        />
+        <label htmlFor="narrative-shared-status" id="narrative-shared-more">
+          ... &nbsp; (<a className="label">show</a> {profiles.length - 10} more)
+        </label>
+        <span id="narrative-shared-rest">{sharedRest}.</span>
+        <label htmlFor="narrative-shared-status" id="narrative-shared-less">
+          &nbsp; (<a className="label">show</a> fewer)
+        </label>
+      </>
+    );
+  }
+  return [
+    <div id="narrative-shared" key="narrative-shared">
+      <span>{sharedFirst}</span>
+      {sharedRestDetails}
+    </div>,
+  ];
+};
+
+/**
+ * Shows some basic details, specifically:
+ *  - author (user id of owner)
+ *  - total cells
+ *  - visibility (public or private)
+ *  - created date
+ *  - data objects
+ * @param {Doc} data - a representation of a narrative
+ * @param {KBaseCache} cache - service data cache
+ * @return {JSX}
+ */
+const detailsHeader = async (data: Doc, cache: KBaseCache) => {
+  if (!data) return <></>;
+  const sharedWith = data.shared_users.filter(
+    (user: string) => user !== Runtime.username()
+  );
+  const cellTypeCounts = countCellTypes(data.cells);
+  const [gold, silver, bronze] = countDataTypes(data);
+  if (!('profiles' in cache)) cache.profiles = {};
+  const authorProfile = await fetchProfile(data.creator, cache.profiles);
+  const sharedWithProfiles = await fetchProfiles(sharedWith, cache.profiles);
+  const authorName = authorProfile.user.realname;
+  const sharedWithLinks = detailsSharedWith(sharedWith, sharedWithProfiles);
+  return (
+    <>
+      <div className="narrative-details">
+        <div className="col">
+          {detailsHeaderItem('Author', [profileLink(data.creator, authorName)])}
+          {detailsHeaderItem('Created on', readableDate(data.creation_date))}
+          {detailsHeaderItem('Last saved', readableDate(data.timestamp))}
+          {detailsHeaderItem(
+            'Visibility',
+            data.is_public ? 'Public' : 'Private'
+          )}
+        </div>
+        <div className="col">
+          {detailsHeaderItem(
+            'Data objects',
+            data.data_objects.length.toString()
+          )}
+          {gold}
+          {silver}
+          {bronze}
+        </div>
+        <div className="col">
+          {detailsHeaderItem('Total cells', data.total_cells.toString())}
+          {detailsHeaderItem('App cells', cellTypeCounts.kbase_app)}
+          {detailsHeaderItem('Markdown cells', cellTypeCounts.markdown)}
+          {detailsHeaderItem('Code Cells', cellTypeCounts.code_cell)}
+        </div>
+      </div>
+      <div className="narrative-details">
+        {data.is_public || !sharedWith.length ? (
+          <></>
+        ) : (
+          detailsHeaderItem('Shared with', sharedWithLinks)
+        )}
+      </div>
+    </>
+  );
+};
+
+interface Props {
+  activeItem: Doc;
+  cache: KBaseCache;
+  updateSearch: () => void;
+  view: string;
+}
+
+interface State {
+  activeItem: Doc;
+  cache: KBaseCache;
+  detailsHeader: JSX.Element;
+}
+
+// Narrative details side panel in the narrative listing.
+export class NarrativeDetails extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    const { activeItem, cache } = this.props;
+    this.state = {
+      activeItem: activeItem,
+      cache: cache,
+      detailsHeader: <></>,
+    };
+  }
+
+  async componentDidMount() {
+    this.setState({
+      detailsHeader: await detailsHeader(
+        this.state.activeItem,
+        this.state.cache
+      ),
+    });
+  }
+
+  async componentDidUpdate(prevProps: Props) {
+    if (prevProps.activeItem === this.props.activeItem) return;
+    this.setState({
+      detailsHeader: await detailsHeader(
+        this.props.activeItem,
+        this.props.cache
+      ),
+    });
+  }
+
+  render() {
+    const { activeItem, cache, updateSearch, view } = this.props;
+    if (!activeItem) {
+      return <div></div>;
+    }
+    const wsid = activeItem.access_group;
+    const narrativeHref = `${
+      Runtime.getConfig().view_routes.narrative
+    }/${wsid}`;
+    let content: JSX.Element | string = '';
+    // Choose which content to show based on selected tab
+    switch (view) {
+      case 'preview':
+        content = <Preview cache={cache} narrative={activeItem} />;
+        break;
+      case 'data':
+      default:
+        content = (
+          <DataView accessGroup={wsid} dataObjects={activeItem.data_objects} />
+        );
+        break;
+    }
+    const keepParams = (link: string) =>
+      keepParamsLinkTo(['limit', 'sort'], link);
+    const tabs = Object.entries({
+      data: {
+        name: 'Data',
+        link: keepParams('?view=data'),
+      },
+      preview: {
+        name: 'Preview',
+        link: keepParams('?view=preview'),
+      },
+    });
+    return (
+      <div
+        className="w-60 bg-white pv2 ph3 bt bb br b--black-20"
+        style={{
+          top: window._env.legacyNav ? '4rem' : '0.75rem',
+          position: 'sticky',
+        }}
+      >
+        <div className="flex justify-between mb3 ma0 pa0 pt2">
+          <div className="f3">
+            <a
+              className="blue pointer no-underline dim"
+              href={narrativeHref}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <span className="fa fa-external-link"></span>
+              <span className="ml2">
+                {activeItem.narrative_title || 'Untitled'}
+              </span>
+            </a>
+            <span className="b f4 gray i ml2">v{activeItem.version}</span>
+          </div>
+          <div className="ml-auto">
+            <ControlMenu
+              narrative={activeItem}
+              doneFn={() => {
+                updateSearch();
+              }}
+            />
+          </div>
+        </div>
+        <div>{this.state.detailsHeader}</div>
+
+        <SubTabs tabs={tabs} className="mb3" selected={view} />
+        {content}
+      </div>
+    );
+  }
 }

--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -208,21 +208,23 @@ export class NarrativeDetails extends React.Component<Props, State> {
   }
 
   async componentDidMount() {
+    const detailsHeaderComponent = await detailsHeader(
+      this.state.activeItem,
+      this.state.cache
+    );
     this.setState({
-      detailsHeader: await detailsHeader(
-        this.state.activeItem,
-        this.state.cache
-      ),
+      detailsHeader: detailsHeaderComponent,
     });
   }
 
   async componentDidUpdate(prevProps: Props) {
     if (prevProps.activeItem === this.props.activeItem) return;
+    const detailsHeaderComponent = await detailsHeader(
+      this.props.activeItem,
+      this.props.cache
+    );
     this.setState({
-      detailsHeader: await detailsHeader(
-        this.props.activeItem,
-        this.props.cache
-      ),
+      detailsHeader: detailsHeaderComponent,
     });
   }
 

--- a/src/client/components/dashboard/NarrativeList/Preview.tsx
+++ b/src/client/components/dashboard/NarrativeList/Preview.tsx
@@ -3,12 +3,13 @@ import marked from 'marked';
 import React, { Component } from 'react';
 
 import { TypeIcon, AppCellIcon, DefaultIcon } from '../../generic/Icon';
-import { Doc, fetchNarrative } from '../../../utils/narrativeData';
+import { Doc, fetchNarrative, KBaseCache } from '../../../utils/narrativeData';
 import Runtime from '../../../utils/runtime';
 
 const DOMPurify = createDOMPurify(window);
 
 interface Props {
+  cache: KBaseCache;
   narrative: Doc;
 }
 
@@ -52,24 +53,28 @@ export default class Preview extends Component<Props, State> {
     this.fetchNarrativeObject();
   }
 
-  fetchNarrativeObject() {
+  async fetchNarrativeObject() {
     this.setState({ isLoading: true });
-    const { narrative } = this.props;
-    const upa = `${narrative.access_group}/${narrative.obj_id}/${narrative.version}`;
-    return fetchNarrative(upa)
-      .then(narr => {
-        narr = narr.data[0].data;
-        const cells = narr.cells ? narr.cells : [];
-        this.setState({
-          isLoading: false,
-          narrObj: narr,
-          cells: cells,
-          error: null,
-        });
-      })
-      .catch(error => {
-        this.setState({ isLoading: false, error: error });
-      });
+    const { cache, narrative } = this.props;
+    /* eslint-disable camelcase */
+    const { access_group, obj_id, version } = narrative;
+    const upa = `${access_group}/${obj_id}/${version}`;
+    /* eslint-enable camelcase */
+    let narrResponse = null;
+    if (!('objects' in cache)) cache.objects = {};
+    try {
+      narrResponse = await fetchNarrative(upa, cache.objects);
+    } catch (error) {
+      this.setState({ isLoading: false, error: error });
+    }
+    const narr = narrResponse.data[0].data || {};
+    const cells = narr.cells ? narr.cells : [];
+    this.setState({
+      isLoading: false,
+      narrObj: narr,
+      cells: cells,
+      error: null,
+    });
   }
 
   render() {

--- a/src/client/components/dashboard/NarrativeList/__tests__/NarrativeDetails.spec.tsx
+++ b/src/client/components/dashboard/NarrativeList/__tests__/NarrativeDetails.spec.tsx
@@ -3,8 +3,10 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-
+import { enableFetchMocks } from 'jest-fetch-mock';
 import { NarrativeDetails } from '../NarrativeDetails';
+
+enableFetchMocks();
 
 const mockDoc = {
   access_group: 12345,
@@ -33,6 +35,24 @@ const mockDoc = {
 
 describe('NarrativeDetails tests', () => {
   test('NarrativeDetails renders', () => {
+    const ownerProfile = JSON.stringify({
+      id: '12345',
+      version: '1.1',
+      result: [
+        [
+          {
+            user: {
+              username: 'owner',
+              realname: 'Owner',
+            },
+          },
+        ],
+      ],
+    });
+    fetchMock.mockResponses(
+      [ownerProfile, { status: 200 }],
+      [ownerProfile, { status: 200 }]
+    );
     const wrapper = shallow(
       <NarrativeDetails
         activeItem={mockDoc}

--- a/src/client/components/dashboard/NarrativeList/__tests__/NarrativeDetails.spec.tsx
+++ b/src/client/components/dashboard/NarrativeList/__tests__/NarrativeDetails.spec.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { NarrativeDetails } from '../NarrativeDetails';
+
+const mockDoc = {
+  access_group: 12345,
+  copied: false,
+  cells: [],
+  creation_date: '2020-07-17T22:04:00+0000',
+  creator: 'owner',
+  data_objects: [],
+  is_public: false,
+  is_narratorial: false,
+  is_temporary: false,
+  narrative_title: 'Narrative title',
+  modified_at: 1595023480707,
+  obj_id: 1,
+  obj_name: `Narrative title`,
+  obj_type_module: 'KBaseNarrative',
+  obj_type_name: 'Narrative',
+  obj_type_version: '4.0',
+  owner: 'owner',
+  shared_users: ['owner'],
+  tags: ['narrative'],
+  timestamp: 1595023480707,
+  total_cells: 1,
+  version: 1,
+};
+
+describe('NarrativeDetails tests', () => {
+  test('NarrativeDetails renders', () => {
+    const wrapper = shallow(
+      <NarrativeDetails
+        activeItem={mockDoc}
+        cache={{}}
+        updateSearch={() => {}}
+        view={'preview'}
+      />
+    );
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.find('div')).toBeTruthy();
+  });
+});

--- a/src/client/components/dashboard/NarrativeList/__tests__/NarrativeList.spec.tsx
+++ b/src/client/components/dashboard/NarrativeList/__tests__/NarrativeList.spec.tsx
@@ -4,8 +4,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { createBrowserHistory } from 'history';
-
+import { enableFetchMocks } from 'jest-fetch-mock';
 import { NarrativeList } from '../';
+
+enableFetchMocks();
 
 describe('NarrativeList tests', () => {
   test('NarrativeList renders', () => {

--- a/src/client/components/generic/Icon.tsx
+++ b/src/client/components/generic/Icon.tsx
@@ -91,8 +91,10 @@ export class AppCellIcon extends Component<AppIconProps, AppIconState> {
       return (
         <span>
           <img
+            height="40"
             src={iconInfo.url}
             style={{ maxWidth: '2.5em', maxHeight: '2.5em', margin: 0 }}
+            width="40"
           />
         </span>
       );

--- a/src/client/components/global_header/Header.tsx
+++ b/src/client/components/global_header/Header.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import Runtime from '../../utils/runtime';
 import { removeCookie } from '../../utils/cookies';
 import { AccountDropdown } from './AccountDropdown';
-import { fetchProfileAPI } from '../../utils/userInfo';
+import { fetchProfile } from '../../utils/userInfo';
 
 import { getUsername, getToken } from '../../utils/auth';
 
@@ -94,7 +94,7 @@ export class Header extends Component<Props, State> {
     if (!username || !username.length) {
       return;
     }
-    const res = await fetchProfileAPI(username);
+    const res = await fetchProfile(username);
     if (res) {
       const avatarOption = res.profile.userdata.avatarOption;
       const gravatarHash = res.profile.synced.gravatarHash;

--- a/src/client/utils/__tests__/auth.spec.ts
+++ b/src/client/utils/__tests__/auth.spec.ts
@@ -34,6 +34,30 @@ describe('getUsername tests', () => {
       done();
     });
   });
+
+  it('Should return a username if there is a token', done => {
+    fetchMock.mockOnce(async req => {
+      return {
+        status: 200,
+        body: JSON.stringify({ user: 'some user' }),
+      };
+    });
+    getUsername(username => {
+      expect(username).toBe('some user');
+      done();
+    });
+  });
+
+  it('Should log a message if there is some other error', done => {
+    fetchMock.mockOnce(async req => {
+      return {
+        status: 200,
+        body: '',
+      };
+    });
+    expect(getUsername(username => {})).toBeUndefined();
+    done();
+  });
 });
 
 describe('getUsernames tests', () => {

--- a/src/client/utils/__tests__/fetchApps.spec.ts
+++ b/src/client/utils/__tests__/fetchApps.spec.ts
@@ -5,9 +5,10 @@
 // This isn't really used anywhere, so it just tests the happy path for now.
 
 import { enableFetchMocks } from 'jest-fetch-mock';
-enableFetchMocks();
 import { fetchApps } from '../fetchApps';
 import Runtime from '../runtime';
+
+enableFetchMocks();
 
 describe('fetchApps tests', () => {
   beforeEach(() => {});
@@ -55,6 +56,14 @@ describe('fetchApps tests', () => {
                 ver: '1.0.0',
                 categories: ['apps'],
               },
+              {
+                id: 'AnotherModule/another_app',
+                module_name: 'AnotherModule',
+                git_commit_hash: 'zyxwvuts',
+                name: 'ANOTHER APP',
+                ver: '1.0.1',
+                categories: ['apps', 'another category'],
+              },
             ],
           ],
         });
@@ -74,6 +83,6 @@ describe('fetchApps tests', () => {
     const appInfos = await fetchApps();
     expect(appInfos.runs).toBeDefined();
     expect(appInfos.details).toBeDefined();
-    expect(appInfos.categories).toEqual(['apps']);
+    expect(appInfos.categories).toEqual(['apps', 'another category']);
   });
 });

--- a/src/client/utils/__tests__/narrativeData.spec.ts
+++ b/src/client/utils/__tests__/narrativeData.spec.ts
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 import { enableFetchMocks } from 'jest-fetch-mock';
-enableFetchMocks();
 import { fetchNarrative, getCurrentUserPermission } from '../narrativeData';
+
+enableFetchMocks();
 
 describe('narrativeData tests', () => {
   const mockWSGetObjects2Ok = (narr: object) => {
@@ -30,15 +31,31 @@ describe('narrativeData tests', () => {
     });
   };
 
-  it('Should return a narrative with the happy case', async () => {
-    const dummyNarr = {
-      data: [{
-        data: {}
-      }],
+  it('Should return a narrative if it exists in the cache', async () => {
+    const dummyResponse = {
+      data: [
+        {
+          data: {},
+        },
+      ],
     };
-    mockWSGetObjects2Ok(dummyNarr);
+    const narrObj = await fetchNarrative('123/45/6', {
+      '123/45/6': {},
+    });
+    expect(JSON.stringify(narrObj)).toEqual(JSON.stringify(dummyResponse));
+  });
+
+  it('Should return a narrative with the happy case', async () => {
+    const dummyResponse = {
+      data: [
+        {
+          data: {},
+        },
+      ],
+    };
+    mockWSGetObjects2Ok(dummyResponse);
     const narrObj = await fetchNarrative('123/45/6');
-    expect(narrObj).toEqual(dummyNarr);
+    expect(narrObj).toEqual(dummyResponse);
   });
 
   it('Should return a set of user permissions with the happy case', async () => {

--- a/src/client/utils/__tests__/narrativeData.spec.ts
+++ b/src/client/utils/__tests__/narrativeData.spec.ts
@@ -32,7 +32,9 @@ describe('narrativeData tests', () => {
 
   it('Should return a narrative with the happy case', async () => {
     const dummyNarr = {
-      data: { narr: 'obj' },
+      data: [{
+        data: {}
+      }],
     };
     mockWSGetObjects2Ok(dummyNarr);
     const narrObj = await fetchNarrative('123/45/6');

--- a/src/client/utils/__tests__/searchNarratives.spec.ts
+++ b/src/client/utils/__tests__/searchNarratives.spec.ts
@@ -12,6 +12,7 @@ import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
 // as of now eslint cannot detect when imported interfaces are used
 import searchNarratives, {
+  sortsLookup,
   SearchOptions, // eslint-disable-line no-unused-vars
 } from '../searchNarratives';
 
@@ -132,6 +133,24 @@ describe('searchNarratives tests', () => {
       pageSize: 10,
     });
     expect(results.count).toEqual(10);
+    expect(results.count).toEqual(results.hits.length);
+  });
+
+  it('searchNarratives should consult the cache first', async () => {
+    const searchParams = {
+      term: '',
+      category: 'own',
+      sort: 'Recently updated',
+      skip: 0,
+      pageSize: 10,
+    };
+    const results = await searchNarratives(searchParams, {
+      [JSON.stringify(searchParams)]: {
+        count: 1,
+        hits: ['sample result'],
+      },
+    });
+    expect(results.count).toEqual(1);
     expect(results.count).toEqual(results.hits.length);
   });
 
@@ -294,12 +313,7 @@ describe('searchNarratives tests', () => {
   });
 
   it('searchNarratives should sort results automatically by some criteria', async () => {
-    const sortings = [
-      'Recently created',
-      'Oldest',
-      'Least recently updated',
-      'Recently updated',
-    ];
+    const sortings = Object.keys(sortsLookup);
     mockSearchOk(
       { term: 'narr', sort: '', category: '', skip: 0, pageSize: 10 },
       TEST_USER

--- a/src/client/utils/__tests__/userInfo.spec.ts
+++ b/src/client/utils/__tests__/userInfo.spec.ts
@@ -3,43 +3,48 @@
  */
 import { enableFetchMocks } from 'jest-fetch-mock';
 import { fetchProfile, fetchProfiles } from '../userInfo';
+
 enableFetchMocks();
 
 const mockProfile = (userId: string, userName: string) => ({
   id: '12345',
   version: '1.1',
-  result: [[{
-    user: {
-      username: userId,
-      realname: userName,
-    },
-    profile: {
-      metadata: { created: '2015-01-14T00:32:40.885Z' },
-      userdata: {
-        researchStatement: 'KBase!',
-        jobTitle: 'Person',
-        affiliations: [
-          {
-            organization: 'Lawrence Berkeley National Laboratory',
-            started: 2012,
-            title: 'Software Developer',
-            ended: 'Present',
+  result: [
+    [
+      {
+        user: {
+          username: userId,
+          realname: userName,
+        },
+        profile: {
+          metadata: { created: '2015-01-14T00:32:40.885Z' },
+          userdata: {
+            researchStatement: 'KBase!',
+            jobTitle: 'Person',
+            affiliations: [
+              {
+                organization: 'Lawrence Berkeley National Laboratory',
+                started: 2012,
+                title: 'Software Developer',
+                ended: 'Present',
+              },
+            ],
+            state: 'California',
+            country: 'United States',
+            city: 'Oakland',
+            postalCode: '',
+            fundingSource: '',
+            gravatarDefault: 'identicon',
+            avatarOption: '',
           },
-        ],
-        state: 'California',
-        country: 'United States',
-        city: 'Oakland',
-        postalCode: '',
-        fundingSource: '',
-        gravatarDefault: 'identicon',
-        avatarOption: '',
+          synced: {
+            gravatarHash: '294da295adeac456edf84b40d8e714d6',
+          },
+          preferences: {},
+        },
       },
-      synced: {
-        gravatarHash: '294da295adeac456edf84b40d8e714d6',
-      },
-      preferences: {},
-    },
-  }]]
+    ],
+  ],
 });
 
 describe('fetchProfile tests', () => {
@@ -82,6 +87,16 @@ describe('fetchProfile tests', () => {
     expect(profile).toBeNull();
   });
 
+  test('fetchProfile should throw an error', async () => {
+    fetchMock.mockOnce(async req => {
+      return {
+        status: 200,
+        body: '{}',
+      };
+    });
+    await expect(() => fetchProfile(userId)).rejects.toThrow();
+  });
+
   test('fetchProfile should throw an error if it does not receive valid JSON', async () => {
     fetchMock.mockOnce(async req => {
       return {
@@ -104,19 +119,20 @@ describe('fetchProfile tests', () => {
         body: JSON.stringify({
           id: '12345',
           version: '1.1',
-          result: [[{
-            [userId]: null,
-            profileNoUser: {},
-            profileNoUserName: { user: {} },
-          }]]
-        })
+          result: [
+            [
+              {
+                [userId]: null,
+                profileNoUser: {},
+                profileNoUserName: { user: {} },
+              },
+            ],
+          ],
+        }),
       };
     });
     const cache = {};
-    await fetchProfiles(
-      [userId, 'profileNoUser', 'profileNoUserName'],
-      cache,
-    );
+    await fetchProfiles([userId, 'profileNoUser', 'profileNoUserName'], cache);
     expect(JSON.stringify(cache)).toBe('{}');
   });
 });

--- a/src/client/utils/fetchApps.ts
+++ b/src/client/utils/fetchApps.ts
@@ -71,7 +71,6 @@ export async function fetchApps(tag = 'release') {
     return acc;
   }, {});
   let detailsJson = await details.json();
-  console.log(detailsJson);
   detailsJson = detailsJson.result[0];
   // Reduce all the details data into an array of category names
   const categories: Array<string> = detailsJson.reduce(

--- a/src/client/utils/narrativeData.ts
+++ b/src/client/utils/narrativeData.ts
@@ -49,13 +49,28 @@ export interface Doc {
   version: number;
 }
 
-export function fetchNarrative(upa: string) {
+/**
+ * The KBaseCache interface
+ */
+export interface KBaseCache {
+  [key: string]: any;
+}
+
+export async function fetchNarrative(upa: string, cache: KBaseCache = {}) {
+  if (upa in cache) {
+    return { data: [{ data: cache[upa] }] };
+  }
   const client = new KBaseServiceClient({
     module: 'Workspace',
     url: Runtime.getConfig().service_routes.workspace,
     authToken: Runtime.token(),
   });
-  return client.call('get_objects2', [{ objects: [{ ref: upa }] }]);
+  const response = await client.call('get_objects2', [
+    { objects: [{ ref: upa }] },
+  ]);
+  const itemUpdate = response.data[0].data;
+  cache[upa] = itemUpdate;
+  return response;
 }
 
 /**

--- a/src/client/utils/userInfo.ts
+++ b/src/client/utils/userInfo.ts
@@ -1,37 +1,18 @@
+import { KBaseServiceClient } from '@kbase/narrative-utils';
 // as of now eslint cannot detect when imported interfaces are used
 import { KBaseCache } from './narrativeData'; // eslint-disable-line no-unused-vars
 import Runtime from '../utils/runtime';
 
-function getUserProfileServiceUrl() {
-  const token = Runtime.token();
-  if (!token) {
-    throw new Error('Tried to fetch profile info without a token.');
-  }
-  return Runtime.getConfig().service_routes.user_profile;
-}
-
 export async function fetchProfiles(usernames: string[], cache: KBaseCache) {
-  const serviceUrl = getUserProfileServiceUrl();
   if (usernames.every(username => username in cache)) {
     return usernames.map(username => cache[username]);
   }
-  const body = {
-    method: 'UserProfile.get_user_profile',
-    params: [usernames],
-  };
-
-  const resp = await fetch(serviceUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
+  const client = new KBaseServiceClient({
+    module: 'UserProfile',
+    url: Runtime.getConfig().service_routes.user_profile,
+    authToken: Runtime.token(),
   });
-  if (resp.status !== 200) {
-    throw new RangeError(`HTTP status not OK: ${resp.status}`);
-  }
-  // console.log('resp', await resp.text());
-  const profiles = (await resp.json()).result[0];
+  const profiles = await client.call('get_user_profile', [usernames]);
   profiles.forEach((profile: any) => {
     if (profile && profile.user && profile.user.username) {
       cache[profile.user.username] = profile;
@@ -40,15 +21,14 @@ export async function fetchProfiles(usernames: string[], cache: KBaseCache) {
   return profiles;
 }
 
-export async function fetchProfile(
-  username: string,
-  cache: KBaseCache = {}
-) {
+export async function fetchProfile(username: string, cache: KBaseCache = {}) {
   let profileArr;
   try {
     profileArr = await fetchProfiles([username], cache);
   } catch (err) {
-    if (err instanceof RangeError) return null;
+    if ('code' in err && err.code !== 200) {
+      return null;
+    }
     throw err;
   }
   const profile = profileArr[0];

--- a/src/client/utils/userInfo.ts
+++ b/src/client/utils/userInfo.ts
@@ -1,30 +1,56 @@
-export {};
+// as of now eslint cannot detect when imported interfaces are used
+import { KBaseCache } from './narrativeData'; // eslint-disable-line no-unused-vars
 import Runtime from '../utils/runtime';
-import { DynamicServiceClient } from '../api/serviceWizard';
 
-export async function fetchProfileAPI(username: string) {
+function getUserProfileServiceUrl() {
   const token = Runtime.token();
   if (!token) {
     throw new Error('Tried to fetch profile info without a token.');
   }
-  const serviceWizardClient = new DynamicServiceClient({
-    moduleName: 'bff',
-    wizardUrl: Runtime.getConfig().service_routes.service_wizard,
-    version: 'beta',
-  });
+  return Runtime.getConfig().service_routes.user_profile;
+}
 
-  const bffServiceUrl = await serviceWizardClient.getServiceUrl();
-  const url = bffServiceUrl + '/fetchUserProfile/' + username;
-  const response = await fetch(url, {
-    method: 'GET',
-  });
-  if (response.status !== 200) {
-    console.warn(response.status, response);
-  } else {
-    try {
-      return await response.json();
-    } catch (err) {
-      console.error('profile fetch failed', response);
-    }
+export async function fetchProfiles(usernames: string[], cache: KBaseCache) {
+  const serviceUrl = getUserProfileServiceUrl();
+  if (usernames.every(username => username in cache)) {
+    return usernames.map(username => cache[username]);
   }
+  const body = {
+    method: 'UserProfile.get_user_profile',
+    params: [usernames],
+  };
+
+  const resp = await fetch(serviceUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (resp.status !== 200) {
+    throw new RangeError(`HTTP status not OK: ${resp.status}`);
+  }
+  // console.log('resp', await resp.text());
+  const profiles = (await resp.json()).result[0];
+  profiles.forEach((profile: any) => {
+    if (profile && profile.user && profile.user.username) {
+      cache[profile.user.username] = profile;
+    }
+  });
+  return profiles;
+}
+
+export async function fetchProfile(
+  username: string,
+  cache: KBaseCache = {}
+) {
+  let profileArr;
+  try {
+    profileArr = await fetchProfiles([username], cache);
+  } catch (err) {
+    if (err instanceof RangeError) return null;
+    throw err;
+  }
+  const profile = profileArr[0];
+  return profile;
 }

--- a/src/static/config.json
+++ b/src/static/config.json
@@ -6,7 +6,7 @@
         "workspace": "/ws",
         "search": "/searchapi2/rpc",
         "service_wizard": "/service_wizard",
-        "user_profile": "/user_profile",
+        "user_profile": "/user_profile/rpc",
         "groups": "/groups"
     },
     "view_routes": {

--- a/src/static/dashboard.css
+++ b/src/static/dashboard.css
@@ -14,6 +14,44 @@
   text-decoration: none;
 }
 
+.narrative-details {
+  display: flex;
+  font-size:.875rem;
+  justify-content: space-between;
+}
+
+.narrative-details .col {
+  overflow: hidden;
+  width:calc(100% / 3);
+}
+
+.narrative-details-key {
+  padding: var(--tachyon-spacing-medium) auto;
+}
+
+.narrative-details-value {
+  font-weight: bold;
+}
+
+#narrative-shared-less,
+#narrative-shared-rest,
+#narrative-shared-status,
+#narrative-shared-status:checked ~ #narrative-shared-more {
+  display: none;
+}
+
+#narrative-shared-more,
+#narrative-shared-status:checked ~ #narrative-shared-less,
+#narrative-shared-status:checked ~ #narrative-shared-rest {
+  display: inline;
+}
+
+#narrative-shared-less a.label,
+#narrative-shared-more a.label {
+  color: #00f;
+  cursor: pointer;
+  text-decoration: underline;
+}
 .narrative-item {
   color: var(--tachyon-black-70);
   text-decoration: none;

--- a/src/static/dashboard.css
+++ b/src/static/dashboard.css
@@ -25,6 +25,10 @@
   width:calc(100% / 3);
 }
 
+.narrative-details a {
+  text-decoration: none;
+}
+
 .narrative-details-key {
   padding: var(--tachyon-spacing-medium) auto;
 }
@@ -50,7 +54,6 @@
 #narrative-shared-more a.label {
   color: #00f;
   cursor: pointer;
-  text-decoration: underline;
 }
 .narrative-item {
   color: var(--tachyon-black-70);


### PR DESCRIPTION
This PR adds new sorting options, real names from users and data type statistics in narrative previews. It also adds a cache to reduce the number of HTTP requests a client makes when using the dashboard.

Lexicographical sorting is added to the possible NarrativeList sorts as well as caching to avoid repeating the same HTTP requests. Narrative previews are also cached. This caching is only done in memory and will be lost if the client navigates away from the page. Even so, this caching is designed so that future versions may use string based key-value stores such as localStorage.

Bare usernames are replaced with real names, and in the narrative detail these names are links to the user's profile. These links have the username as their title attribute so that it may be seen on hover. While this is not visible in mobile views, the username is listed on the user profile. These usernames are also cached to prevent extraneous HTTP requests. The summary also identifies the most common data types within a narrative. Further, for shared narratives only the first few users are to show up by default but there is an option to see the rest.