### PR TITLE
Search fixes and refresh

### DIFF
--- a/src/client/components/dashboard/NarrativeList/Filters.tsx
+++ b/src/client/components/dashboard/NarrativeList/Filters.tsx
@@ -19,6 +19,7 @@ interface Props {
   history: History;
   loading: boolean;
   onSetSearch: (searchParams: SearchParams) => void;
+  search: string;
   sort: string;
 }
 
@@ -34,10 +35,11 @@ export class Filters extends Component<Props, State> {
     }
     this.state = {
       searchParams: {
-        term: '',
+        term: props.search,
         sort: sort,
       },
     };
+    this.handleSearch = this.handleSearch.bind(this);
   }
 
   componentDidMount() {
@@ -45,8 +47,17 @@ export class Filters extends Component<Props, State> {
   }
 
   // Handle an onSetVal event from SearchInput
-  handleSearch(val: string): void {
+  handleSearch(val: string, updateLocation: boolean = true): void {
     const searchParams = this.state.searchParams;
+    if (updateLocation) {
+      const queryParams = new URLSearchParams(location.search);
+      if (!val) {
+        queryParams.delete('search');
+      } else {
+        queryParams.set('search', val);
+      }
+      this.props.history.push(`?${queryParams.toString()}`);
+    }
     searchParams.term = val;
     if (this.props.onSetSearch) {
       this.props.onSetSearch(searchParams);
@@ -56,14 +67,14 @@ export class Filters extends Component<Props, State> {
   // Handle an onSelect event from FilterDropdown
   handleFilter(val: string, updateLocation: boolean = true): void {
     const { category } = this.props;
-    const queryParams = new URLSearchParams(location.search);
-    const sortSlug = sortsLookup[val];
-    if (sortSlug === sortSlugDefault) {
-      queryParams.delete('sort');
-    } else {
-      queryParams.set('sort', sortSlug);
-    }
     if (updateLocation) {
+      const queryParams = new URLSearchParams(location.search);
+      const sortSlug = sortsLookup[val];
+      if (sortSlug === sortSlugDefault) {
+        queryParams.delete('sort');
+      } else {
+        queryParams.set('sort', sortSlug);
+      }
       const prefix = '/' + (category === 'own' ? '' : `${category}/`);
       const newLocation = `${prefix}?${queryParams.toString()}`;
       this.props.history.push(newLocation);
@@ -87,8 +98,9 @@ export class Filters extends Component<Props, State> {
         <div className="pv3">
           <SearchInput
             loading={Boolean(this.props.loading)}
-            onSetVal={this.handleSearch.bind(this)}
+            onSetVal={this.handleSearch}
             placeholder="Search Narratives"
+            value={this.props.search}
           />
         </div>
 

--- a/src/client/components/dashboard/NarrativeList/Filters.tsx
+++ b/src/client/components/dashboard/NarrativeList/Filters.tsx
@@ -43,32 +43,24 @@ export class Filters extends Component<Props, State> {
   }
 
   getSearchParamsFromProps(props: Props) {
-    let sort = sortSlugDefault;
-    if (props.sort) {
-      sort = sorts[props.sort];
-    }
     return {
       term: props.search,
-      sort: sort,
+      sort: sorts[props.sort],
     };
   }
 
   // Handle an onSetVal event from SearchInput
-  handleSearch(val: string, updateLocation: boolean = true): void {
+  handleSearch(val: string): void {
     const searchParams = this.state.searchParams;
-    if (updateLocation) {
-      const queryParams = new URLSearchParams(location.search);
-      if (!val) {
-        queryParams.delete('search');
-      } else {
-        queryParams.set('search', val);
-      }
-      this.props.history.push(`?${queryParams.toString()}`);
+    const queryParams = new URLSearchParams(location.search);
+    if (!val) {
+      queryParams.delete('search');
+    } else {
+      queryParams.set('search', val);
     }
+    this.props.history.push(`?${queryParams.toString()}`);
     searchParams.term = val;
-    if (this.props.onSetSearch) {
-      this.props.onSetSearch(searchParams);
-    }
+    this.props.onSetSearch(searchParams);
   }
 
   // Handle an onSelect event from FilterDropdown

--- a/src/client/components/dashboard/NarrativeList/ItemList.tsx
+++ b/src/client/components/dashboard/NarrativeList/ItemList.tsx
@@ -62,7 +62,7 @@ export class ItemList extends Component<Props, State> {
     const css = itemClasses[status];
     const upa = `${item.access_group}/${item.obj_id}/${item.version}`;
     const keepParams = (link: string) =>
-      keepParamsLinkTo(['limit', 'sort', 'view'], link);
+      keepParamsLinkTo(['limit', 'search', 'sort', 'view'], link);
     const { category } = this.props;
     const prefix = '/' + (category === 'own' ? '' : `${category}/`);
     // Action to select an item to view details

--- a/src/client/components/dashboard/NarrativeList/__tests__/Filters.spec.tsx
+++ b/src/client/components/dashboard/NarrativeList/__tests__/Filters.spec.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { mount } from 'enzyme';
+import { createBrowserHistory } from 'history';
+import { enableFetchMocks } from 'jest-fetch-mock';
+import { Filters } from '../Filters';
+
+enableFetchMocks();
+
+const dummyEvent = {
+  preventDefault: () => {},
+  type: 'mousedown',
+  button: 0,
+};
+
+const mockFilters = (search: string = '') =>
+  mount(
+    <Filters
+      category={'public'}
+      history={createBrowserHistory()}
+      loading={false}
+      onSetSearch={(searchParams, invalidateCache = false) => {}}
+      search={search}
+      sort={'-updated'}
+    />
+  );
+
+describe('Filters tests', () => {
+  test('Filters renders', () => {
+    const wrapper = mockFilters();
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.find('filters')).toBeTruthy();
+  });
+
+  test('Clicking refresh fires handleRefresh', () => {
+    const wrapper = mockFilters();
+    expect(wrapper.find('button.refresh').first()).toBeTruthy();
+    // Click Refresh:
+    wrapper.find('button.refresh').simulate('click', dummyEvent);
+  });
+
+  test('Clicking filter fires handleFilter', () => {
+    const wrapper = mockFilters();
+    expect(wrapper.find('a.ba').first()).toBeTruthy();
+    // Open the filter dropdowns:
+    wrapper.find('a.ba').simulate('click', dummyEvent);
+    expect(wrapper.find('a.db.hover-bg-blue').first()).toBeTruthy();
+    // Click on the one with index 0:
+    wrapper
+      .find('a.db.hover-bg-blue')
+      .first()
+      .simulate('click', dummyEvent);
+    expect(wrapper.find('a.ba').first()).toBeTruthy();
+    // Open the filter dropdowns:
+    wrapper.find('a.ba').simulate('click', dummyEvent);
+    expect(wrapper.find('a.db.hover-bg-blue').at(1)).toBeTruthy();
+    // Click on the one with index 1:
+    wrapper
+      .find('a.db.hover-bg-blue')
+      .at(1)
+      .simulate('click', dummyEvent);
+  });
+
+  test('Changing search term fires handleSearch', async () => {
+    const wrapper = mockFilters();
+    expect(wrapper.find('input.ba').first()).toBeTruthy();
+    wrapper.find('input.ba').simulate('change', { target: { value: 'test' } });
+    // This setTimeout is to simulate a pause in user's typing
+    // see DEBOUNCE in SearchInput
+    await new Promise(resolve => window.setTimeout(() => resolve(), 500));
+    const wrapperVal = mockFilters('test');
+    wrapperVal
+      .find('input.ba')
+      .simulate('change', { target: { value: 'test test' } });
+    await new Promise(resolve => window.setTimeout(() => resolve(), 500));
+  });
+});

--- a/src/client/components/dashboard/NarrativeList/__tests__/NarrativeList.spec.tsx
+++ b/src/client/components/dashboard/NarrativeList/__tests__/NarrativeList.spec.tsx
@@ -18,6 +18,7 @@ describe('NarrativeList tests', () => {
         id={1}
         limit={20}
         obj={1}
+        search={''}
         sort={'-updated'}
         ver={1}
         view={'preview'}

--- a/src/client/components/dashboard/NarrativeList/index.tsx
+++ b/src/client/components/dashboard/NarrativeList/index.tsx
@@ -41,6 +41,7 @@ interface Props {
   id: number;
   limit: number;
   obj: number;
+  search: string;
   sort: string;
   ver: number;
   view: string;
@@ -53,7 +54,7 @@ const upaKey = (id: number, obj: number, ver: number) => `${id}/${obj}/${ver}`;
 export class NarrativeList extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    const { category, limit } = this.props;
+    const { category, limit, search } = this.props;
     const sortDefault = Object.values(sorts)[0];
     this.state = {
       // Currently active narrative result, selected on the left and shown on the right
@@ -68,7 +69,7 @@ export class NarrativeList extends Component<Props, State> {
       // parameters to send to the searchNarratives function
       pages: parseInt((limit / PAGE_SIZE).toString()),
       searchParams: {
-        term: '',
+        term: search,
         sort: sortDefault,
         category: category,
         pageSize: limit || PAGE_SIZE,
@@ -86,14 +87,15 @@ export class NarrativeList extends Component<Props, State> {
   }
 
   async componentDidUpdate(prevProps: Props) {
-    const { category } = this.props;
+    const { category, search } = this.props;
     const pageSize = this.props.limit || PAGE_SIZE;
     const sort = sorts[this.props.sort];
-    const nextSearchParams = { term: '', sort, category, pageSize };
+    const nextSearchParams = { term: search, sort, category, pageSize };
     const performSearchCondition =
       prevProps.category !== this.props.category ||
       prevProps.id !== this.props.id ||
       prevProps.limit !== this.props.limit ||
+      prevProps.search !== this.props.search ||
       prevProps.sort !== this.props.sort;
     if (performSearchCondition) {
       await this.performSearch(nextSearchParams);
@@ -201,6 +203,7 @@ export class NarrativeList extends Component<Props, State> {
             history={this.props.history}
             loading={this.state.loading}
             onSetSearch={this.handleSearch.bind(this)}
+            search={this.props.search}
             sort={sort}
           />
 

--- a/src/client/components/dashboard/NarrativeList/index.tsx
+++ b/src/client/components/dashboard/NarrativeList/index.tsx
@@ -106,11 +106,14 @@ export class NarrativeList extends Component<Props, State> {
   }
 
   // Handle an onSetSearch callback from Filters
-  handleSearch(searchP: { term: string; sort: string }): void {
+  async handleSearch(
+    searchP: { term: string; sort: string },
+    invalidateCache: boolean = false
+  ): Promise<void> {
     const searchParams = this.state.searchParams;
     searchParams.term = searchP.term;
     searchParams.sort = searchP.sort;
-    this.performSearch(searchParams);
+    await this.performSearch(searchParams, invalidateCache);
   }
 
   // Handle an onSelectItem callback from ItemList
@@ -120,14 +123,18 @@ export class NarrativeList extends Component<Props, State> {
   }
 
   // Perform a search and return the Promise for the fetch
-  async performSearch(searchParams?: SearchOptions) {
+  async performSearch(
+    searchParams?: SearchOptions,
+    invalidateCache: boolean = false
+  ) {
     if (!searchParams) {
       searchParams = this.state.searchParams;
     }
     this.setState({ loading: true });
     const requestedId = this.props.id;
     const cache = this.state.cache;
-    if (!('search' in cache)) cache.search = {};
+    const initializeCacheCondition = invalidateCache || !('search' in cache);
+    if (initializeCacheCondition) cache.search = {};
     const resp = await searchNarratives(searchParams, cache.search);
     // TODO handle error from server
     if (!resp || !resp.hits) return;
@@ -187,11 +194,7 @@ export class NarrativeList extends Component<Props, State> {
           </div>
 
           {/* New narrative button */}
-          <a
-            className="pointer dim dib pa2 white br2 bg-dark-green dib no-underline"
-            style={{ marginTop: '1rem', height: '2.25rem' }}
-            href={NEW_NARR_URL}
-          >
+          <a className="button clickable narrative-new" href={NEW_NARR_URL}>
             <i className="mr1 fa fa-plus"></i> New Narrative
           </a>
         </div>

--- a/src/client/components/dashboard/index.tsx
+++ b/src/client/components/dashboard/index.tsx
@@ -47,6 +47,7 @@ export class Dashboard extends Component<Props, State> {
     const queryParams = new URLSearchParams(this.props.location.search);
     const paramLimit = queryParams.get('limit');
     const limit = paramLimit ? parseInt(paramLimit) : 0;
+    const search = queryParams.get('search') || '';
     const sort = queryParams.get('sort') || sortSlugDefault;
     const view = queryParams.get('view') || 'data';
     if (this.state.loading) return <>Loading...</>;
@@ -58,6 +59,7 @@ export class Dashboard extends Component<Props, State> {
           id={paramId}
           limit={limit}
           obj={paramObj}
+          search={search}
           sort={sort}
           ver={paramVer}
           view={view}

--- a/src/client/components/generic/SearchInput.tsx
+++ b/src/client/components/generic/SearchInput.tsx
@@ -30,6 +30,11 @@ export class SearchInput extends Component<Props, State> {
     this.handleInput = this.handleInput.bind(this);
   }
 
+  componentDidUpdate(prevProps: Props) {
+    const initializeCondition = prevProps.value !== this.props.value;
+    if (initializeCondition) this.setState({ value: '' });
+  }
+
   setVal(value: string) {
     if (this.props.onSetVal) {
       this.props.onSetVal(value);

--- a/src/client/components/generic/SearchInput.tsx
+++ b/src/client/components/generic/SearchInput.tsx
@@ -7,6 +7,7 @@ const DEBOUNCE = 250;
 interface Props {
   onSetVal: (value: string) => void;
   loading: boolean;
+  value?: string;
   placeholder?: string;
 }
 
@@ -24,12 +25,12 @@ export class SearchInput extends Component<Props, State> {
     super(props);
     this.inputID = 'search-input' + String(Math.floor(Math.random() * 1000000));
     this.state = {
-      value: '',
+      value: props.value || '',
     };
+    this.handleInput = this.handleInput.bind(this);
   }
 
   setVal(value: string) {
-    this.setState({ value });
     if (this.props.onSetVal) {
       this.props.onSetVal(value);
     }
@@ -37,7 +38,8 @@ export class SearchInput extends Component<Props, State> {
 
   // From an input event, call setVal at most every DEBOUNCE milliseconds
   handleInput(ev: React.FormEvent<HTMLInputElement>) {
-    const value = ev.currentTarget.value.trim();
+    const value = ev.currentTarget.value;
+    this.setState({ value });
     const callback = () => {
       this.setVal(value);
     };
@@ -64,7 +66,8 @@ export class SearchInput extends Component<Props, State> {
           type="text"
           id={this.inputID}
           placeholder={this.props.placeholder || 'Search'}
-          onInput={this.handleInput.bind(this)}
+          onChange={this.handleInput}
+          value={this.state.value || this.props.value || ''}
           style={{ paddingLeft: '2rem' }}
         />
       </div>

--- a/src/static/dashboard.css
+++ b/src/static/dashboard.css
@@ -3,10 +3,24 @@
   --tachyon-black-20: rgba(0,0,0,.2);
   --tachyon-black-30: rgba(0,0,0,.3);
   --tachyon-black-70: rgba(0,0,0,.7);
+  --tachyon-dark-green: #137752;
   --tachyon-green: #19a974;
+  --tachyon-light-gray: #eee;
   --tachyon-lightest-blue: #cdecff;
   --tachyon-spacing-medium: 1rem;
+  --tachyon-spacing-small: .5rem;
   --white: #fff;
+}
+
+.button {
+  background-color: var(--tachyon-dark-green);
+  border-radius: .25em;
+  color: var(--white);
+  cursor: pointer;
+  display: inline-block;
+  height: 2.25rem;
+  padding: var(--tachyon-spacing-small);
+  text-decoration: none;
 }
 
 .dataview a, .dataview a:visited {
@@ -14,15 +28,37 @@
   text-decoration: none;
 }
 
+.filters {
+  align-items: center;
+  background-color: var(--tachyon-light-gray);
+  display: flex;
+}
+
+/* .clickable and .inactive are the same as tachyon's .dim (for now) */
+.clickable, .inactive {
+  opacity: 1;
+  transition: opacity .15s ease-in;
+}
+
+.clickable:focus, .clickable:hover, .inactive:focus, .inactive:hover {
+  opacity: .5;
+  transition: opacity .15s ease-in;
+}
+
+.clickable:active, .inactive:active {
+  opacity: .8;
+  transition: opacity .15s ease-out;
+}
+
 .narrative-details {
   display: flex;
-  font-size:.875rem;
+  font-size: .875rem;
   justify-content: space-between;
 }
 
 .narrative-details .col {
   overflow: hidden;
-  width:calc(100% / 3);
+  width: calc(100% / 3);
 }
 
 .narrative-details a {
@@ -35,6 +71,10 @@
 
 .narrative-details-value {
   font-weight: bold;
+}
+
+.narrative-new {
+  margin-top: 1rem;
 }
 
 #narrative-shared-less,
@@ -55,6 +95,7 @@
   color: #00f;
   cursor: pointer;
 }
+
 .narrative-item {
   color: var(--tachyon-black-70);
   text-decoration: none;
@@ -78,8 +119,14 @@
 .narrative-item-outer.inactive {
   background-color: var(--white);
   color: var(--tachyon-black-70);
-  opacity:1;
-  transition: opacity .15s ease-in;
+}
+
+.refresh {
+  border: none;
+}
+
+.refresh .loading {
+  animation: fa-spin 2s infinite linear;
 }
 
 .subtab, .tab {
@@ -97,21 +144,6 @@
 
 .subtab.active {
   color: var(--tachyon-green);
-}
-
-.subtab.inactive, .tab.inactive {
-  opacity: 1;
-  transition: opacity .15s ease-in;
-}
-
-.subtab.inactive:active, .tab.inactive:active {
-  opacity: .8;
-  transition: opacity .15s ease-out;
-}
-
-.subtab.inactive:focus, .subtab.inactive:hover,
-.tab.inactive:focus, .tab.inactive:hover {
-  opacity: .5;
 }
 
 .subtab-container {


### PR DESCRIPTION
This PR fixes SCT-2875, SCT-2876 and SCT-2877. The main semantic change is to make the search a query parameter in the URL. Then the search state can be entirely derived from the URL. Preserving this query parameter when clicking an item in the list of results will therefore preserve the filters the user has specified and the list will not change unexpectedly.

The search term is now cleared when a user changes tabs. There are other ways to ensure the consistency of the user's experience, such as maintaining the term and continuing to apply the search, but this is the smallest change that hopefully will eliminate user confusion and reduce user surprise. It may be a surprise to remove the search term, but it is confusing to have a term present and not applied.

Finally, users may now click the refresh button to invalidate the cache of search results and perform a new search with the same parameters. This allows users who keep the narratives view open while other narrative actions occur to see the latest state. Sample actions include renaming narratives, creating new narratives and having new narratives shared with the user.