### PR TITLE
Provided an app level gravatarDefault.

### DIFF
--- a/src/client/components/global_header/Header.tsx
+++ b/src/client/components/global_header/Header.tsx
@@ -98,7 +98,8 @@ export class Header extends Component<Props, State> {
     if (res) {
       const avatarOption = res.profile.userdata.avatarOption;
       const gravatarHash = res.profile.synced.gravatarHash;
-      const gravatarDefault = res.profile.userdata.gravatarDefault;
+      const gravatarDefault =
+        res.profile.userdata.gravatarDefault || 'identicon';
       const username = res.user.username;
       const realname = res.user.realname;
       this.setState({

--- a/src/client/components/global_header/__tests__/Header.spec.tsx
+++ b/src/client/components/global_header/__tests__/Header.spec.tsx
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Header } from '../Header';
+
+describe('Header tests', () => {
+  it('<Header> should render', () =>
+    expect(shallow(<Header title="title" />)).toBeTruthy());
+});


### PR DESCRIPTION
Some KBase user profiles appear to lack a `gravatarDefault` key which led to broken user avatars. If no such key exists the `identicon` is now used.