### PR TITLE
Address PTV-1631 - narrative ownership changes on save

### DIFF
--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -139,7 +139,7 @@ const detailsHeader = async (data: Doc, cache: KBaseCache) => {
   const cellTypeCounts = countCellTypes(data.cells);
   const [gold, silver, bronze] = countDataTypes(data);
   if (!('profiles' in cache)) cache.profiles = {};
-  const authorProfile = await fetchProfile(data.owner, cache.profiles);
+  const authorProfile = await fetchProfile(data.creator, cache.profiles);
   const sharedWithProfiles = await fetchProfiles(sharedWith, cache.profiles);
   const authorName = authorProfile.user.realname;
   const sharedWithLinks = detailsSharedWith(sharedWith, sharedWithProfiles);
@@ -147,7 +147,7 @@ const detailsHeader = async (data: Doc, cache: KBaseCache) => {
     <>
       <div className="narrative-details">
         <div className="col">
-          {detailsHeaderItem('Author', [profileLink(data.owner, authorName)])}
+          {detailsHeaderItem('Author', [profileLink(data.creator, authorName)])}
           {detailsHeaderItem('Created on', readableDate(data.creation_date))}
           {detailsHeaderItem('Last saved', readableDate(data.timestamp))}
           {detailsHeaderItem(

--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -175,8 +175,8 @@ const detailsHeader = async (data: Doc, cache: KBaseCache) => {
         {data.is_public || !sharedWith.length ? (
           <></>
         ) : (
-            detailsHeaderItem('Shared with', sharedWithLinks)
-          )}
+          detailsHeaderItem('Shared with', sharedWithLinks)
+        )}
       </div>
     </>
   );
@@ -234,8 +234,9 @@ export class NarrativeDetails extends React.Component<Props, State> {
       return <div></div>;
     }
     const wsid = activeItem.access_group;
-    const narrativeHref = `${Runtime.getConfig().view_routes.narrative
-      }/${wsid}`;
+    const narrativeHref = `${
+      Runtime.getConfig().view_routes.narrative
+    }/${wsid}`;
     let content: JSX.Element | string = '';
     // Choose which content to show based on selected tab
     switch (view) {

--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -175,8 +175,8 @@ const detailsHeader = async (data: Doc, cache: KBaseCache) => {
         {data.is_public || !sharedWith.length ? (
           <></>
         ) : (
-          detailsHeaderItem('Shared with', sharedWithLinks)
-        )}
+            detailsHeaderItem('Shared with', sharedWithLinks)
+          )}
       </div>
     </>
   );
@@ -234,9 +234,8 @@ export class NarrativeDetails extends React.Component<Props, State> {
       return <div></div>;
     }
     const wsid = activeItem.access_group;
-    const narrativeHref = `${
-      Runtime.getConfig().view_routes.narrative
-    }/${wsid}`;
+    const narrativeHref = `${Runtime.getConfig().view_routes.narrative
+      }/${wsid}`;
     let content: JSX.Element | string = '';
     // Choose which content to show based on selected tab
     switch (view) {

--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -139,7 +139,7 @@ const detailsHeader = async (data: Doc, cache: KBaseCache) => {
   const cellTypeCounts = countCellTypes(data.cells);
   const [gold, silver, bronze] = countDataTypes(data);
   if (!('profiles' in cache)) cache.profiles = {};
-  const authorProfile = await fetchProfile(data.creator, cache.profiles);
+  const authorProfile = await fetchProfile(data.owner, cache.profiles);
   const sharedWithProfiles = await fetchProfiles(sharedWith, cache.profiles);
   const authorName = authorProfile.user.realname;
   const sharedWithLinks = detailsSharedWith(sharedWith, sharedWithProfiles);
@@ -147,7 +147,7 @@ const detailsHeader = async (data: Doc, cache: KBaseCache) => {
     <>
       <div className="narrative-details">
         <div className="col">
-          {detailsHeaderItem('Author', [profileLink(data.creator, authorName)])}
+          {detailsHeaderItem('Author', [profileLink(data.owner, authorName)])}
           {detailsHeaderItem('Created on', readableDate(data.creation_date))}
           {detailsHeaderItem('Last saved', readableDate(data.timestamp))}
           {detailsHeaderItem(
@@ -175,8 +175,8 @@ const detailsHeader = async (data: Doc, cache: KBaseCache) => {
         {data.is_public || !sharedWith.length ? (
           <></>
         ) : (
-          detailsHeaderItem('Shared with', sharedWithLinks)
-        )}
+            detailsHeaderItem('Shared with', sharedWithLinks)
+          )}
       </div>
     </>
   );
@@ -234,9 +234,8 @@ export class NarrativeDetails extends React.Component<Props, State> {
       return <div></div>;
     }
     const wsid = activeItem.access_group;
-    const narrativeHref = `${
-      Runtime.getConfig().view_routes.narrative
-    }/${wsid}`;
+    const narrativeHref = `${Runtime.getConfig().view_routes.narrative
+      }/${wsid}`;
     let content: JSX.Element | string = '';
     // Choose which content to show based on selected tab
     switch (view) {

--- a/src/client/utils/searchNarratives.ts
+++ b/src/client/utils/searchNarratives.ts
@@ -161,13 +161,13 @@ export default async function searchNarratives(
   switch (category) {
     case 'own':
       params.filters.fields.push({
-        field: 'creator',
+        field: 'owner',
         term: username,
       });
       break;
     case 'shared':
       params.filters.fields.push({
-        field: 'creator',
+        field: 'owner',
         not_term: username,
       });
       params.filters.fields.push({


### PR DESCRIPTION
Switches the filter for narrative ownership from the "creator" field to the "owner" field. 

The "creator" in this case is the workspace object "creator", which is the last user who made a change to the narrative object; similar to "last saved by", but not quite. It is not the narrative creator, which is the user who originally created a narrative and is stored in the typed data property of the workspace object. It never changes, even when it is copied.

Without the change, a narrative will appear in the "My Narratives" list of whoever last saved the narrative. This is not noticeable for narratives only operated by one user, but is mayhem for collaborative narratives with more than one editor.