### PR TITLE
Revisions to new object reverter tool and dropdown viewer

### DIFF
--- a/src/client/components/dashboard/NarrativeList/ControlMenu/CopyItem.tsx
+++ b/src/client/components/dashboard/NarrativeList/ControlMenu/CopyItem.tsx
@@ -27,6 +27,7 @@ export default class CopyItem extends Component<ControlMenuItemProps, State> {
     const config = Runtime.getConfig();
     const wsId = this.props.narrative.access_group;
     const objId = this.props.narrative.obj_id;
+    const { version } = this.props.narrative;
     const narrativeService = new DynamicServiceClient({
       moduleName: 'NarrativeService',
       wizardUrl: config.service_routes.service_wizard,
@@ -35,7 +36,7 @@ export default class CopyItem extends Component<ControlMenuItemProps, State> {
     try {
       await narrativeService.call('copy_narrative', [
         {
-          workspaceRef: `${wsId}/${objId}`,
+          workspaceRef: `${wsId}/${objId}/${version}`,
           workspaceId: wsId,
           newName: this.state.newName,
         },

--- a/src/client/components/dashboard/NarrativeList/ControlMenu/DeleteNarrative.tsx
+++ b/src/client/components/dashboard/NarrativeList/ControlMenu/DeleteNarrative.tsx
@@ -190,7 +190,7 @@ export default class DeleteNarrative extends Component<
 
   renderConfirmation() {
     return (
-      <div style={{textAlign: 'center'}}>
+      <div style={{ textAlign: 'center' }}>
         <div className="pb2">
           <p>
             Deleting a Narrative will permanently remove it and all its data.

--- a/src/client/components/dashboard/NarrativeList/ControlMenu/DeleteNarrative.tsx
+++ b/src/client/components/dashboard/NarrativeList/ControlMenu/DeleteNarrative.tsx
@@ -190,7 +190,7 @@ export default class DeleteNarrative extends Component<
 
   renderConfirmation() {
     return (
-      <>
+      <div style={{textAlign: 'center'}}>
         <div className="pb2">
           <p>
             Deleting a Narrative will permanently remove it and all its data.
@@ -210,7 +210,7 @@ export default class DeleteNarrative extends Component<
             Cancel
           </DashboardButton>
         </div>
-      </>
+      </div>
     );
   }
 

--- a/src/client/components/dashboard/NarrativeList/ControlMenu/RevertNarrative.tsx
+++ b/src/client/components/dashboard/NarrativeList/ControlMenu/RevertNarrative.tsx
@@ -202,20 +202,20 @@ class RevertNarrative extends Component<ControlMenuItemProps, ComponentState> {
 
   renderConfirmation() {
     return (
-      <>
+      <div style={{textAlign: 'center'}}>
         <div className="pb2">
           <p>
-            Reverting a narrative to a previous version is permanent and may
-            cause data loss.
+            Reverting a narrative will create a new version identical to v{this.props.narrative.version}. 
           </p>
-          <p style={{ fontWeight: 'bold' }}>This action cannot be undone!</p>
+          <p>
+            This new narrative can be reverted to an earlier version at any time.
+          </p>
         </div>
-        <div className="pb2">Continue?</div>
+        <div className="pb2" style={{fontWeight: 'bold'}}>Do you wish to continue?</div>
         <div>
           <DashboardButton
             onClick={() => this.doRevert()}
-            bgcolor={'red'}
-            textcolor={'white'}
+            bgcolor={'lightblue'}
           >
             Revert
           </DashboardButton>
@@ -223,7 +223,7 @@ class RevertNarrative extends Component<ControlMenuItemProps, ComponentState> {
             Cancel
           </DashboardButton>
         </div>
-      </>
+      </div>
     );
   }
 

--- a/src/client/components/dashboard/NarrativeList/ControlMenu/RevertNarrative.tsx
+++ b/src/client/components/dashboard/NarrativeList/ControlMenu/RevertNarrative.tsx
@@ -202,16 +202,20 @@ class RevertNarrative extends Component<ControlMenuItemProps, ComponentState> {
 
   renderConfirmation() {
     return (
-      <div style={{textAlign: 'center'}}>
+      <div style={{ textAlign: 'center' }}>
         <div className="pb2">
           <p>
-            Reverting a narrative will create a new version identical to v{this.props.narrative.version}. 
+            Reverting a narrative will create a new version identical to v
+            {this.props.narrative.version}.
           </p>
           <p>
-            This new narrative can be reverted to an earlier version at any time.
+            This new narrative can be reverted to an earlier version at any
+            time.
           </p>
         </div>
-        <div className="pb2" style={{fontWeight: 'bold'}}>Do you wish to continue?</div>
+        <div className="pb2" style={{ fontWeight: 'bold' }}>
+          Do you wish to continue?
+        </div>
         <div>
           <DashboardButton
             onClick={() => this.doRevert()}

--- a/src/client/components/dashboard/NarrativeList/ItemList.tsx
+++ b/src/client/components/dashboard/NarrativeList/ItemList.tsx
@@ -89,7 +89,8 @@ export class ItemList extends Component<Props, State> {
           <div className={css.inner}>
             <div className="ma0 mb2 pa0 f5">
               {item.narrative_title || 'Untitled'}
-              {category === 'own' && this.renderDropdown(upa, item.version, idx)}
+              {category === 'own' &&
+                this.renderDropdown(upa, item.version, idx)}
             </div>
             <p className="ma0 pa0 f7">
               Updated {timeago.format(item.timestamp)} by {item.creator}

--- a/src/client/components/dashboard/NarrativeList/ItemList.tsx
+++ b/src/client/components/dashboard/NarrativeList/ItemList.tsx
@@ -89,7 +89,7 @@ export class ItemList extends Component<Props, State> {
           <div className={css.inner}>
             <div className="ma0 mb2 pa0 f5">
               {item.narrative_title || 'Untitled'}
-              {category === 'own' && this.renderDropdown(upa, item.version)}
+              {category === 'own' && this.renderDropdown(upa, item.version, idx)}
             </div>
             <p className="ma0 pa0 f7">
               Updated {timeago.format(item.timestamp)} by {item.creator}
@@ -101,19 +101,21 @@ export class ItemList extends Component<Props, State> {
     );
   };
 
-  renderDropdown(upa: string, version: number) {
+  renderDropdown(upa: string, version: number, idx: number) {
     const { selected } = this.props;
     const selectedNarr = selected.substring(0, selected.lastIndexOf('/'));
     const selectedVersion = +selected.split('/')[2];
     const narr = upa.substring(0, upa.lastIndexOf('/'));
-    if (narr !== selectedNarr) {
+
+    // only give dropdown to selected version or default highlighted version on first load
+    if (narr !== selectedNarr && !(selected === '0/0/0' && idx === 0)) {
       return <></>;
     }
     return (
       <VersionDropdown
         upa={upa}
         version={version}
-        selectedVersion={selectedVersion}
+        selectedVersion={selected === '0/0/0' ? version : selectedVersion}
         category={this.props.category}
         history={this.props.history}
       />

--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -192,7 +192,7 @@ interface Props {
   // takes precedence over active item if it was fetched from narrative service
   previousVersion: Doc | null;
   loading: boolean;
-  history: History
+  history: History;
 }
 
 interface State {
@@ -237,13 +237,15 @@ export class NarrativeDetails extends React.Component<Props, State> {
   renderVersionDropdown() {
     const { activeItem, previousVersion, category, history } = this.props;
     const { access_group, obj_id, version } = activeItem;
-    return <VersionDropdown
-              upa={`${access_group}/${obj_id}/${version}`}
-              version={activeItem.version}
-              selectedVersion={previousVersion?.version ?? activeItem.version}
-              category={category}
-              history={history}
-            />
+    return (
+      <VersionDropdown
+        upa={`${access_group}/${obj_id}/${version}`}
+        version={activeItem.version}
+        selectedVersion={previousVersion?.version ?? activeItem.version}
+        category={category}
+        history={history}
+      />
+    );
   }
 
   render() {
@@ -313,8 +315,7 @@ export class NarrativeDetails extends React.Component<Props, State> {
             <span className="b f4 gray i ml2">
               {category === 'own'
                 ? this.renderVersionDropdown()
-                : `v${displayItem.version}`
-              }
+                : `v${displayItem.version}`}
             </span>
           </div>
           <div className="ml-auto">

--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -13,6 +13,8 @@ import ControlMenu from './ControlMenu/ControlMenu';
 import DataView from './DataView';
 import Preview from './Preview';
 import { LoadingSpinner } from '../../generic/LoadingSpinner';
+import { History } from 'History';
+import { VersionDropdown } from './VersionDropdown';
 
 function detailsHeaderItem(key: string, value: string | JSX.Element[]) {
   return (
@@ -190,6 +192,7 @@ interface Props {
   // takes precedence over active item if it was fetched from narrative service
   previousVersion: Doc | null;
   loading: boolean;
+  history: History
 }
 
 interface State {
@@ -229,6 +232,18 @@ export class NarrativeDetails extends React.Component<Props, State> {
     this.setState({
       detailsHeader: detailsHeaderComponent,
     });
+  }
+
+  renderVersionDropdown() {
+    const { activeItem, previousVersion, category, history } = this.props;
+    const { access_group, obj_id, version } = activeItem;
+    return <VersionDropdown
+              upa={`${access_group}/${obj_id}/${version}`}
+              version={activeItem.version}
+              selectedVersion={previousVersion?.version ?? activeItem.version}
+              category={category}
+              history={history}
+            />
   }
 
   render() {
@@ -296,10 +311,10 @@ export class NarrativeDetails extends React.Component<Props, State> {
               </span>
             </a>
             <span className="b f4 gray i ml2">
-              v{displayItem.version}
-              {previousVersion && (
-                <span className="b f4 gray i"> of {activeItem.version}</span>
-              )}
+              {category === 'own'
+                ? this.renderVersionDropdown()
+                : `v${displayItem.version}`
+              }
             </span>
           </div>
           <div className="ml-auto">

--- a/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
+++ b/src/client/components/dashboard/NarrativeList/NarrativeDetails.tsx
@@ -13,7 +13,7 @@ import ControlMenu from './ControlMenu/ControlMenu';
 import DataView from './DataView';
 import Preview from './Preview';
 import { LoadingSpinner } from '../../generic/LoadingSpinner';
-import { History } from 'History';
+import { History } from 'history';
 import { VersionDropdown } from './VersionDropdown';
 
 function detailsHeaderItem(key: string, value: string | JSX.Element[]) {

--- a/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
+++ b/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
@@ -117,7 +117,9 @@ export class VersionDropdown extends Component<Props, State> {
       <OutsideClickListener dismissToggle={this.dismissToggle.bind(this)}>
         <div className="relative ml2" style={{ display: 'inline-block' }}>
           <span onClick={(e) => this.setVersionToggle(e)}>
-            <span className="f5 gray i"> v{this.state.selectedVersion}</span>
+            <span className="f5 gray i"> v{this.state.selectedVersion}
+              {this.state.selectedVersion < version && ` of ${version}`}
+            </span>
             <i className="fa fa-caret-down ml1 gray"></i>
           </span>
           {this.state.versionToggle && (

--- a/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
+++ b/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
@@ -15,6 +15,39 @@ interface State {
   selectedVersion: number;
 }
 
+// wrapper for dismissing dropdown on outside click
+class OutsideClickListener extends Component<{ dismissToggle: () => void }> {
+  wrapperRef: HTMLDivElement | null = null;
+
+  constructor(props: any) {
+    super(props);
+    this.setWrapperRef = this.setWrapperRef.bind(this);
+    this.handleOutsideClick = this.handleOutsideClick.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleOutsideClick);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleOutsideClick);
+  }
+
+  handleOutsideClick(event: any) {
+    if (this.wrapperRef && !this.wrapperRef?.contains(event.target)) {
+      this.props.dismissToggle();
+    }
+  }
+
+  setWrapperRef(node: HTMLDivElement) {
+    this.wrapperRef = node;
+  }
+
+  render() {
+    return <div ref={this.setWrapperRef}>{this.props.children}</div>;
+  }
+}
+
 export class VersionDropdown extends Component<Props, State> {
   state = {
     versionToggle: false,
@@ -27,6 +60,10 @@ export class VersionDropdown extends Component<Props, State> {
     this.setState((prevState) => ({
       versionToggle: !prevState.versionToggle,
     }));
+  }
+
+  dismissToggle() {
+    this.setState({ versionToggle: false });
   }
 
   handleSelectVersion(e: MouseEvent, upa: string, version: number) {
@@ -76,26 +113,28 @@ export class VersionDropdown extends Component<Props, State> {
       .map((_, n) => n + 1)
       .reverse();
     return (
-      <div className="relative ml2" style={{ display: 'inline-block' }}>
-        <span onClick={(e) => this.setVersionToggle(e)}>
-          <span className="f5 gray i"> v{this.state.selectedVersion}</span>
-          <i className="fa fa-caret-down ml1 gray"></i>
-        </span>
-        {this.state.versionToggle && (
-          <div
-            className="ba b--black-30 bg-white db fr absolute"
-            style={{
-              boxShadow: '0 2px 3px #aaa',
-              zIndex: 1,
-              width: '8rem',
-              maxHeight: '200px',
-              overflowY: 'scroll',
-            }}
-          >
-            {versions.map((ver) => this.itemView(ver))}
-          </div>
-        )}
-      </div>
+      <OutsideClickListener dismissToggle={this.dismissToggle.bind(this)}>
+        <div className="relative ml2" style={{ display: 'inline-block' }}>
+          <span onClick={(e) => this.setVersionToggle(e)}>
+            <span className="f5 gray i"> v{this.state.selectedVersion}</span>
+            <i className="fa fa-caret-down ml1 gray"></i>
+          </span>
+          {this.state.versionToggle && (
+            <div
+              className="ba b--black-30 bg-white db fr absolute"
+              style={{
+                boxShadow: '0 2px 3px #aaa',
+                zIndex: 1,
+                width: '8rem',
+                maxHeight: '200px',
+                overflowY: 'scroll',
+              }}
+            >
+              {versions.map((ver) => this.itemView(ver))}
+            </div>
+          )}
+        </div>
+      </OutsideClickListener>
     );
   }
 }

--- a/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
+++ b/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
@@ -58,7 +58,7 @@ export class VersionDropdown extends Component<Props, State> {
   componentDidUpdate() {
     // state should match again whenever component updates
     if (this.state.selectedVersion !== this.props.selectedVersion) {
-      this.setState({selectedVersion: this.props.selectedVersion});
+      this.setState({ selectedVersion: this.props.selectedVersion });
     }
   }
 
@@ -77,10 +77,10 @@ export class VersionDropdown extends Component<Props, State> {
     const { history } = this.props;
     const keepParams = (link: string) =>
       keepParamsLinkTo(['limit', 'search', 'sort', 'view'], link);
-      this.setState({
-        versionToggle: false,
-        selectedVersion: version,
-      });
+    this.setState({
+      versionToggle: false,
+      selectedVersion: version,
+    });
     history.push(keepParams(upa)(history.location));
     // prevent parent link from redirecting back to current version URL
     e.preventDefault();
@@ -103,7 +103,7 @@ export class VersionDropdown extends Component<Props, State> {
       <span
         key={version}
         className="db pa2 pointer hover-bg-blue hover-white f5 fs-normal"
-        style={{color: 'black', fontWeight: 'normal'}}
+        style={{ color: 'black', fontWeight: 'normal' }}
         onClick={(e) =>
           this.handleSelectVersion(e, `${prefix}${newUpa}`, version)
         }
@@ -125,7 +125,9 @@ export class VersionDropdown extends Component<Props, State> {
       <OutsideClickListener dismissToggle={this.dismissToggle.bind(this)}>
         <div className="relative ml2" style={{ display: 'inline-block' }}>
           <span onClick={(e) => this.setVersionToggle(e)}>
-            <span className="gray i"> v{this.state.selectedVersion}
+            <span className="gray i">
+              {' '}
+              v{this.state.selectedVersion}
               {this.state.selectedVersion < version && ` of ${version}`}
             </span>
             <i className="fa fa-caret-down ml1 gray"></i>

--- a/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
+++ b/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
@@ -55,6 +55,13 @@ export class VersionDropdown extends Component<Props, State> {
     selectedVersion: this.props.selectedVersion,
   };
 
+  componentDidUpdate() {
+    // state should match again whenever component updates
+    if (this.state.selectedVersion !== this.props.selectedVersion) {
+      this.setState({selectedVersion: this.props.selectedVersion});
+    }
+  }
+
   setVersionToggle(event: MouseEvent) {
     event.preventDefault();
     this.setState((prevState) => ({
@@ -70,11 +77,11 @@ export class VersionDropdown extends Component<Props, State> {
     const { history } = this.props;
     const keepParams = (link: string) =>
       keepParamsLinkTo(['limit', 'search', 'sort', 'view'], link);
+      this.setState({
+        versionToggle: false,
+        selectedVersion: version,
+      });
     history.push(keepParams(upa)(history.location));
-    this.setState({
-      versionToggle: false,
-      selectedVersion: version,
-    });
     // prevent parent link from redirecting back to current version URL
     e.preventDefault();
   }
@@ -95,7 +102,8 @@ export class VersionDropdown extends Component<Props, State> {
     return (
       <span
         key={version}
-        className="db pa2 pointer hover-bg-blue hover-white"
+        className="db pa2 pointer hover-bg-blue hover-white f5 fs-normal"
+        style={{color: 'black', fontWeight: 'normal'}}
         onClick={(e) =>
           this.handleSelectVersion(e, `${prefix}${newUpa}`, version)
         }
@@ -117,7 +125,7 @@ export class VersionDropdown extends Component<Props, State> {
       <OutsideClickListener dismissToggle={this.dismissToggle.bind(this)}>
         <div className="relative ml2" style={{ display: 'inline-block' }}>
           <span onClick={(e) => this.setVersionToggle(e)}>
-            <span className="f5 gray i"> v{this.state.selectedVersion}
+            <span className="gray i"> v{this.state.selectedVersion}
               {this.state.selectedVersion < version && ` of ${version}`}
             </span>
             <i className="fa fa-caret-down ml1 gray"></i>

--- a/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
+++ b/src/client/components/dashboard/NarrativeList/VersionDropdown.tsx
@@ -2,19 +2,6 @@ import React, { Component, MouseEvent } from 'react';
 import { keepParamsLinkTo } from '../utils';
 import { History } from 'history';
 
-interface Props {
-  upa: string;
-  version: number;
-  selectedVersion: number;
-  category: string;
-  history: History;
-}
-
-interface State {
-  versionToggle: boolean;
-  selectedVersion: number;
-}
-
 // wrapper for dismissing dropdown on outside click
 class OutsideClickListener extends Component<{ dismissToggle: () => void }> {
   wrapperRef: HTMLDivElement | null = null;
@@ -44,14 +31,27 @@ class OutsideClickListener extends Component<{ dismissToggle: () => void }> {
   }
 
   render() {
-    return <div ref={this.setWrapperRef}>{this.props.children}</div>;
+    return (
+      <div style={{ display: 'inline-block' }} ref={this.setWrapperRef}>
+        {this.props.children}
+      </div>
+    );
   }
 }
-
+interface Props {
+  upa: string;
+  version: number;
+  selectedVersion: number;
+  category: string;
+  history: History;
+}
+interface State {
+  versionToggle: boolean;
+  selectedVersion: number;
+}
 export class VersionDropdown extends Component<Props, State> {
   state = {
     versionToggle: false,
-    // selectedVersion: this.props.version
     selectedVersion: this.props.selectedVersion,
   };
 
@@ -96,7 +96,6 @@ export class VersionDropdown extends Component<Props, State> {
       <span
         key={version}
         className="db pa2 pointer hover-bg-blue hover-white"
-        // onClick={(e) => this.handleSelectVersion(e, version)}
         onClick={(e) =>
           this.handleSelectVersion(e, `${prefix}${newUpa}`, version)
         }
@@ -108,6 +107,8 @@ export class VersionDropdown extends Component<Props, State> {
 
   render() {
     const { version } = this.props;
+    // prevent scrollbar when all elements can fit in dropdown
+    const overflowStyle = version > 6 ? 'scroll' : 'hidden';
     const versions = Array(version)
       .fill(null)
       .map((_, n) => n + 1)
@@ -127,7 +128,7 @@ export class VersionDropdown extends Component<Props, State> {
                 zIndex: 1,
                 width: '8rem',
                 maxHeight: '200px',
-                overflowY: 'scroll',
+                overflowY: overflowStyle,
               }}
             >
               {versions.map((ver) => this.itemView(ver))}

--- a/src/client/components/dashboard/NarrativeList/__tests__/NarrativeDetails.spec.tsx
+++ b/src/client/components/dashboard/NarrativeList/__tests__/NarrativeDetails.spec.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { enableFetchMocks } from 'jest-fetch-mock';
 import { NarrativeDetails } from '../NarrativeDetails';
+import { createBrowserHistory } from 'history';
 
 enableFetchMocks();
 
@@ -62,6 +63,7 @@ describe('NarrativeDetails tests', () => {
         previousVersion={null}
         category={''}
         loading={false}
+        history={createBrowserHistory()}
       />
     );
     expect(wrapper).toBeTruthy();

--- a/src/client/components/dashboard/NarrativeList/index.tsx
+++ b/src/client/components/dashboard/NarrativeList/index.tsx
@@ -304,6 +304,7 @@ export class NarrativeList extends Component<Props, State> {
                 previousVersion={this.state.oldVersionDoc}
                 category={category}
                 loading={this.state.oldVersionLoading}
+                history={this.props.history}
               />
             ) : (
               <></>


### PR DESCRIPTION
* Adds "vX of X" display on left side panel
* Adds additional version dropdown on right side in NarrativeDetails component
* Improves style consistency between narrative control action confirmation modals
* Fixes bug where version dropdown doesn't appear on first page load
* Improves wording to describe what happens when a user copies a previous version
* Allows version dropdown to dismiss when user clicks outside of it
* Removes scroll bar in version dropdown when the number of items fit within the window