### PR TITLE
Update jinja2 to v3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sanic==19.9.0
 requests==2.21.0
-Jinja2==2.11.3
+Jinja2==3.0.3


### PR DESCRIPTION
Fixes breaking dependency related to markupsafe. See more info [here](https://github.com/pallets/markupsafe/issues/290)