### PR TITLE
use built in dynamic service module instead of import from node_modules

### DIFF
--- a/src/client/components/dashboard/NarrativeList/ControlMenu/RevertNarrative.tsx
+++ b/src/client/components/dashboard/NarrativeList/ControlMenu/RevertNarrative.tsx
@@ -96,11 +96,11 @@ class RevertNarrative extends Component<ControlMenuItemProps, ComponentState> {
     const { narrative } = this.props;
 
     const narrativeClient = new DynamicServiceClient({
-      moduleName: "NarrativeService",
+      moduleName: 'NarrativeService',
       authToken: Runtime.token(),
       wizardUrl: Runtime.getConfig().service_routes.service_wizard,
-      version: 'dev'
-    })
+      version: 'dev',
+    });
 
     try {
       const revertResult = await narrativeClient.call(

--- a/src/client/components/dashboard/NarrativeList/ControlMenu/RevertNarrative.tsx
+++ b/src/client/components/dashboard/NarrativeList/ControlMenu/RevertNarrative.tsx
@@ -4,10 +4,7 @@ import ControlMenuItemProps from './ControlMenuItemProps';
 import DashboardButton from '../../../generic/DashboardButton';
 import { LoadingSpinner } from '../../../generic/LoadingSpinner';
 import Runtime from '../../../../utils/runtime';
-import {
-  KBaseServiceClient,
-  KBaseDynamicServiceClient,
-} from '@kbase/narrative-utils';
+import { DynamicServiceClient } from '../../../../api/serviceWizard';
 import { RouteComponentProps, withRouter } from 'react-router';
 import ControlMenu from './ControlMenu';
 
@@ -97,11 +94,13 @@ class RevertNarrative extends Component<ControlMenuItemProps, ComponentState> {
     });
 
     const { narrative } = this.props;
-    const narrativeClient = new KBaseDynamicServiceClient({
-      module: 'NarrativeService',
-      version: 'dev',
+
+    const narrativeClient = new DynamicServiceClient({
+      moduleName: "NarrativeService",
       authToken: Runtime.token(),
-    });
+      wizardUrl: Runtime.getConfig().service_routes.service_wizard,
+      version: 'dev'
+    })
 
     try {
       const revertResult = await narrativeClient.call(

--- a/src/client/utils/narrativeData.ts
+++ b/src/client/utils/narrativeData.ts
@@ -102,13 +102,13 @@ export async function fetchOldVersionDoc(
   ver: number
 ): Promise<Doc> {
   const client = new DynamicServiceClient({
-    moduleName: "NarrativeService",
+    moduleName: 'NarrativeService',
     authToken: Runtime.token(),
     wizardUrl: Runtime.getConfig().service_routes.service_wizard,
-    version: 'dev'
+    version: 'dev',
   });
 
   return client.call('get_narrative_doc', [
-    {narrative_upa: `${id}/${obj}/${ver}`}
+    { narrative_upa: `${id}/${obj}/${ver}` },
   ]);
 }

--- a/src/client/utils/narrativeData.ts
+++ b/src/client/utils/narrativeData.ts
@@ -1,8 +1,6 @@
 /* eslint-disable camelcase */
-import {
-  KBaseServiceClient,
-  KBaseDynamicServiceClient,
-} from '@kbase/narrative-utils';
+import { KBaseServiceClient } from '@kbase/narrative-utils';
+import { DynamicServiceClient } from '../api/serviceWizard';
 import Runtime from '../utils/runtime';
 
 /**
@@ -103,14 +101,14 @@ export async function fetchOldVersionDoc(
   obj: number,
   ver: number
 ): Promise<Doc> {
-  const client = new KBaseDynamicServiceClient({
-    module: 'NarrativeService',
-    version: 'dev',
+  const client = new DynamicServiceClient({
+    moduleName: "NarrativeService",
     authToken: Runtime.token(),
+    wizardUrl: Runtime.getConfig().service_routes.service_wizard,
+    version: 'dev'
   });
 
-  const response = await client.call('get_narrative_doc', [
-    { narrative_upa: `${id}/${obj}/${ver}` },
+  return client.call('get_narrative_doc', [
+    {narrative_upa: `${id}/${obj}/${ver}`}
   ]);
-  return response;
 }


### PR DESCRIPTION
* replaces `@kbase/narrative-utils` KBaseDynamicServiceClient with internal dynamic service interface
* Fixes issue where dynamic service will only make calls to the `ci` environment.
* https://github.com/kbaseIncubator/narrative-utils/blob/master/src/config.ts#L22