### PR TITLE
Fix share dropdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sanic==19.9.0
 requests==2.21.0
-Jinja2==2.11.3
+Jinja2==3.0.3

--- a/src/client/components/dashboard/NarrativeList/ControlMenu/sharing/PermSearch.tsx
+++ b/src/client/components/dashboard/NarrativeList/ControlMenu/sharing/PermSearch.tsx
@@ -93,8 +93,8 @@ export default class PermSearch extends Component<PermSearchProps> {
             container: (base: any) => ({ ...base, flex: 2 }),
           }}
           menuPortalTarget={document.body}
-          onInputChange={this.handleInputChange.bind(this)}
-          onChange={this.handleUserChange.bind}
+          onInputChange={this.handleInputChange}
+          onChange={(e) => this.handleUserChange(e as any[])}
         />
         <Select
           defaultValue={this.permOptions[0]}


### PR DESCRIPTION
The event handler for the PermSearch dropdown was incorrectly defined, resulting in `function.prototype.bind called on incompatible target`. This fix wraps the handler in an arrow function to make the action actually work.